### PR TITLE
Group & Permission logic

### DIFF
--- a/core/schema.sql
+++ b/core/schema.sql
@@ -5,6 +5,7 @@ drop table if exists snuids cascade;
 drop table if exists reserved_usernames cascade;
 drop table if exists groups cascade;
 drop table if exists group_relations cascade;
+drop table if exists group_reachable_cache cascade;
 drop table if exists user_memberships cascade;
 drop table if exists permissions cascade;
 drop table if exists permission_requirements cascade;
@@ -81,6 +82,14 @@ create table groups (
 
 -- OR relationship for groups.
 create table group_relations (
+  idx serial primary key,
+  supergroup_idx integer not null references groups(idx) on delete cascade,
+  subgroup_idx integer not null references groups(idx) on delete cascade,
+  unique (supergroup_idx, subgroup_idx)
+);
+
+-- Cache for reachable group relation for a group
+create table group_reachable_cache (
   idx serial primary key,
   supergroup_idx integer not null references groups(idx) on delete cascade,
   subgroup_idx integer not null references groups(idx) on delete cascade,

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -90,7 +90,6 @@ create table group_relations (
 
 -- Cache for reachable group relation for a group
 create table group_reachable_cache (
-  idx serial primary key,
   supergroup_idx integer not null references groups(idx) on delete cascade,
   subgroup_idx integer not null references groups(idx) on delete cascade,
   unique (supergroup_idx, subgroup_idx)

--- a/core/src/model/groups.ts
+++ b/core/src/model/groups.ts
@@ -15,7 +15,7 @@ interface GroupReachable {
   [groupIdx: number]: Array<number>
 }
 
-export interface GroupRelation {
+export interface GroupRelationship {
   supergroupIdx: number
   subgroupIdx: number
 }
@@ -91,7 +91,7 @@ export default class Groups {
     return result.rows[0].idx
   }
 
-  private async getAllGroupRelation(client: PoolClient): Promise<Array<GroupRelation>> {
+  private async getAllGroupRelation(client: PoolClient): Promise<Array<GroupRelationship>> {
     const query = 'SELECT supergroup_idx, subgroup_idx FROM group_relations'
     const result = await client.query(query)
     return result.rows.map(row => this.rowToGroupRelation(row))
@@ -125,7 +125,7 @@ export default class Groups {
 
   private async updateGroupReachableCache(client: PoolClient): Promise<void> {
     let groupIdxArray: Array<number> = []
-    let groupRelationArray: Array<GroupRelation> = []
+    let groupRelationArray: Array<GroupRelationship> = []
     const firstGroupReachable: GroupReachable = {}
     const cache: GroupReachable = {}
 
@@ -177,7 +177,7 @@ export default class Groups {
     }
   }
 
-  private rowToGroupRelation(row: any): GroupRelation {
+  private rowToGroupRelation(row: any): GroupRelationship {
     return {
       supergroupIdx: row.supergroup_idx,
       subgroupIdx: row.subgroup_idx,

--- a/core/src/model/permissions.ts
+++ b/core/src/model/permissions.ts
@@ -47,7 +47,7 @@ export default class Permissions {
   }
 
   public async checkUserHavePermission(client: PoolClient, userIdx: number, permissionIdx: number): Promise<boolean> {
-    const userReachableGroups = await this.model.users.getUserReachableGroups(client, userIdx)
+    const userReachableGroups = Array.from(await this.model.users.getUserReachableGroups(client, userIdx))
     const permissionRequirements = await this.getAllPermissionRequirements(client, permissionIdx)
 
     for (const pr of permissionRequirements) {

--- a/core/src/model/permissions.ts
+++ b/core/src/model/permissions.ts
@@ -40,14 +40,21 @@ export default class Permissions {
     return result.rows[0].idx
   }
 
-  public async getAllPermissionRequirements(client:PoolClient, idx: number): Promise<number> {
+  public async getAllPermissionRequirements(client: PoolClient, idx: number): Promise<Array<number>> {
     const query = 'SELECT group_idx FROM permission_requirements WHERE permission_idx = $1'
     const result = await client.query(query, [idx])
     return result.rows.map(row => row.group_idx)
   }
 
-  public async checkUserHavePermission(client: PoolClient, idx: number, userIdx: number): Promise<boolean> {
-    const reachableGroups = await this.model.groups.getReachableGroup(client)
-    return false
+  public async checkUserHavePermission(client: PoolClient, userIdx: number, permissionIdx: number): Promise<boolean> {
+    const userReachableGroups = await this.model.users.getUserReachableGroups(client, userIdx)
+    const permissionRequirements = await this.getAllPermissionRequirements(client, permissionIdx)
+
+    for (const pr of permissionRequirements) {
+      if (!userReachableGroups.includes(pr)) {
+        return false
+      }
+    }
+    return true
   }
 }

--- a/core/src/model/permissions.ts
+++ b/core/src/model/permissions.ts
@@ -31,12 +31,23 @@ export default class Permissions {
     return result.rows[0].idx
   }
 
-  public async deletePermissionRequirement(client: PoolClient, permissionRequirementIdx: number): Promise<number> {
+  public async deletePermissionRequirement(client: PoolClient, idx: number): Promise<number> {
     const query = 'DELETE FROM permission_requirements WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [permissionRequirementIdx])
+    const result = await client.query(query, [idx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
+  }
+
+  public async getAllPermissionRequirements(client:PoolClient, idx: number): Promise<number> {
+    const query = 'SELECT group_idx FROM permission_requirements WHERE permission_idx = $1'
+    const result = await client.query(query, [idx])
+    return result.rows.map(row => row.group_idx)
+  }
+
+  public async checkUserHavePermission(client: PoolClient, idx: number, userIdx: number): Promise<boolean> {
+    const reachableGroups = await this.model.groups.getReachableGroup(client)
+    return false
   }
 }

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -119,18 +119,18 @@ export default class Users {
     return result.rows.map(row => this.rowToUserMembership(row))
   }
 
-  public async getUserReachableGroups(client: PoolClient, userIdx: number): Promise<Array<number>> {
-    const reachableGroups = await this.model.groups.getReachableGroup(client)
+  public async getUserReachableGroups(client: PoolClient, userIdx: number): Promise<Set<number>> {
     const userMemberships = await this.getAllUserMemberships(client, userIdx)
-    const groupSet = new Set()
+    const groupSet = new Set<number>()
 
-    userMemberships.forEach(userMembership => {
-      reachableGroups[userMembership.groupIdx].forEach(gi => {
+    for (const userMembership of userMemberships) {
+      const reachableGroups = await this.model.groups.getGroupReachableArray(client, userMembership.groupIdx)
+      reachableGroups.forEach(gi => {
         groupSet.add(gi)
       })
-    })
+    }
 
-    return Array.from(groupSet)
+    return groupSet
   }
 
   private rowToUser(row: any): User {

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -15,6 +15,11 @@ export interface User {
   preferredLanguage: Language
 }
 
+export interface UserMembership {
+  userIdx: number
+  groupIdx: number
+}
+
 export default class Users {
   constructor(private readonly model: Model) {
   }
@@ -105,6 +110,29 @@ export default class Users {
     return result.rows[0].idx
   }
 
+  public async getAllUserMemberships(client: PoolClient, userIdx: number): Promise<Array<UserMembership>> {
+    const query = 'SELECT user_idx, group_idx FROM user_memberships WHERE user_idx = $1'
+    const result = await client.query(query, [userIdx])
+    if (result.rows.length === 0) {
+      throw new NoSuchEntryError()
+    }
+    return result.rows.map(row => this.rowToUserMembership(row))
+  }
+
+  public async getUserReachableGroups(client: PoolClient, userIdx: number): Promise<Array<number>> {
+    const reachableGroups = await this.model.groups.getReachableGroup(client)
+    const userMemberships = await this.getAllUserMemberships(client, userIdx)
+    const groupSet = new Set()
+
+    userMemberships.forEach(userMembership => {
+      reachableGroups[userMembership.groupIdx].forEach(gi => {
+        groupSet.add(gi)
+      })
+    })
+
+    return Array.from(groupSet)
+  }
+
   private rowToUser(row: any): User {
     return {
       idx: row.idx,
@@ -113,6 +141,13 @@ export default class Users {
       uid: row.uid,
       shell: row.shell,
       preferredLanguage: row.preferred_language,
+    }
+  }
+
+  private rowToUserMembership(row: any): UserMembership {
+    return {
+      userIdx: row.user_idx,
+      groupIdx: row.group_idx,
     }
   }
 }

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -93,8 +93,8 @@ test('get reachable group object', async t => {
 
     const result = await model.groups.getReachableGroup(c)
 
-    t.deepEqual(result[g[0]], [g[0], g[1], g[2], g[3], g[4]])
-    t.deepEqual(result[g[1]], [g[1], g[3], g[4]])
+    t.deepEqual(result[g[0]].sort(), [g[0], g[1], g[2], g[3], g[4]].sort())
+    t.deepEqual(result[g[1]].sort(), [g[1], g[3], g[4]].sort())
     t.deepEqual(result[g[2]], [g[2]])
     t.deepEqual(result[g[3]], [g[3]])
     t.deepEqual(result[g[4]], [g[4]])

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -91,12 +91,21 @@ test('get reachable group object', async t => {
     await createGroupRelation(c, model, g[1], g[3])
     await createGroupRelation(c, model, g[1], g[4])
 
-    const result = await model.groups.getReachableGroup(c)
+    let result: Array<number> = []
 
-    t.deepEqual(result[g[0]].sort(), [g[0], g[1], g[2], g[3], g[4]].sort())
-    t.deepEqual(result[g[1]].sort(), [g[1], g[3], g[4]].sort())
-    t.deepEqual(result[g[2]], [g[2]])
-    t.deepEqual(result[g[3]], [g[3]])
-    t.deepEqual(result[g[4]], [g[4]])
+    result = await model.groups.getGroupReachableArray(c, g[0])
+    t.deepEqual(result.sort(), [g[0], g[1], g[2], g[3], g[4]].sort())
+
+    result = await model.groups.getGroupReachableArray(c, g[1])
+    t.deepEqual(result.sort(), [g[1], g[3], g[4]].sort())
+
+    result = await model.groups.getGroupReachableArray(c, g[2])
+    t.deepEqual(result, [g[2]])
+
+    result = await model.groups.getGroupReachableArray(c, g[3])
+    t.deepEqual(result, [g[3]])
+
+    result = await model.groups.getGroupReachableArray(c, g[4])
+    t.deepEqual(result, [g[4]])
   })
 })

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -7,7 +7,7 @@ import Config from '../../src/config'
 import { Translation } from '../../src/model/translation'
 import { NoSuchEntryError } from '../../src/model/errors'
 
-import { createGroup, createUser } from '../test_utils'
+import { createGroup, createUser, createGroupRelation } from '../test_utils'
 
 const config: Config = JSON.parse(fs.readFileSync('config.test.json', {encoding: 'utf-8'}))
 
@@ -75,5 +75,28 @@ test('set owner group', async t => {
 
     await model.groups.setOwnerGroup(c, groupIdx, null)
     t.is((await model.groups.getByIdx(c, groupIdx)).ownerGroupIdx, null)
+  })
+})
+
+test('get reachable group object', async t => {
+  await model.pgDo(async c => {
+    const g: Array<number> = []
+    const range: Array<number> = [...Array(5).keys()]
+    for (const _ of range) {
+      g.push(await createGroup(c, model))
+    }
+
+    await createGroupRelation(c, model, g[0], g[1])
+    await createGroupRelation(c, model, g[0], g[2])
+    await createGroupRelation(c, model, g[1], g[3])
+    await createGroupRelation(c, model, g[1], g[4])
+
+    const result = await model.groups.getReachableGroup(c)
+
+    t.deepEqual(result[g[0]], [g[0], g[1], g[2], g[3], g[4]])
+    t.deepEqual(result[g[1]], [g[1], g[3], g[4]])
+    t.deepEqual(result[g[2]], [g[2]])
+    t.deepEqual(result[g[3]], [g[3]])
+    t.deepEqual(result[g[4]], [g[4]])
   })
 })

--- a/core/test/model/users.test.ts
+++ b/core/test/model/users.test.ts
@@ -94,3 +94,18 @@ test('add and delete user membership', async t => {
     t.fail()
   })
 })
+
+test('get all user memberships', async t => {
+  await model.pgDo(async c => {
+    const userIdx = await createUser(c, model)
+    const groupIdx1 = await createGroup(c, model)
+    const groupIdx2 = await createGroup(c, model)
+
+    const idx1 = await model.users.addUserMembership(c, userIdx, groupIdx1)
+    const idx2 = await model.users.addUserMembership(c, userIdx, groupIdx2)
+
+    const result = await model.users.getAllUserMemberships(c, userIdx)
+
+    t.deepEqual(result.map(um => um.groupIdx).sort(), [groupIdx1, groupIdx2].sort())
+  })
+})

--- a/core/test/test_utils.ts
+++ b/core/test/test_utils.ts
@@ -26,6 +26,10 @@ export async function createGroup(c: PoolClient, model: Model): Promise<number> 
   return await model.groups.create(c, name, description)
 }
 
+export async function createGroupRelation(c: PoolClient, model: Model, supergroupIdx: number, subgroupIdx: number) {
+  return await model.groups.addGroupRelation(c, supergroupIdx, subgroupIdx)
+}
+
 export async function createPermission(c: PoolClient, model: Model): Promise<number> {
   const name = {
     ko: uuid(),

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "target": "es6",
+    "lib": ["es2016"],
     "module": "commonjs",
     "strict": true,
     "noUnusedLocals": false,


### PR DESCRIPTION
캐시를 DB에 넣어서 consistency를 유지하기로 했습니다.

테스트 그룹 구조는 다음과 같습니다.

```
    0
   / \
  1   2
 /\
3  4
```

2, 4의 그룹을 require하는 퍼미션을 만들고
0의 그룹의 사용자 => true
1의 그룹의 사용자 => false
1, 2그룹의 사용자 => true
를 assert 합니다.