### PR TITLE
Front index

### DIFF
--- a/front/components/AppCenter.vue
+++ b/front/components/AppCenter.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+  앱센터
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+
+@Component({})
+
+export default class AppCenter extends Vue {
+
+}
+</script>

--- a/front/components/HeaderMenu.vue
+++ b/front/components/HeaderMenu.vue
@@ -1,0 +1,124 @@
+<template>
+  <div>
+	  <ul class="ulhead">
+      <li class="lilink"><a href="http://www.snucse.org">{{menuSel[0]}}  <i class="el-icon-more-outline"></i></a></li>
+      <li name="nav" class="isActive" @click="selectMenu(0)"><nuxt-link to="/">{{menuSel[1]}}</nuxt-link></li>
+      <li name="nav" class="limenu" @click="selectMenu(1)"><nuxt-link to="/support">{{menuSel[2]}}</nuxt-link></li>
+      <li name="nav" class="limenu" @click="selectMenu(2)"><nuxt-link to="/appcenter">{{menuSel[3]}}</nuxt-link></li>
+      <li class="lilink"><a href="http://cse.snu.ac.kr">{{menuSel[4]}}  <i class="el-icon-more-outline"></i></a></li>
+      <li class="lilink"><a href="http://bacchus.snucse.org">{{menuSel[5]}}  <i class="el-icon-more-outline"></i></a></li>
+      <li class="lilink" @click="selectMenu(3)"><nuxt-link to="/help">{{menuSel[6]}}  <i class="el-icon-question"></i></nuxt-link></li>
+      <li class="libutton"><el-button class="button" type="primary" @click="changeLang"> {{menuSel[7]}}</el-button></li>
+	  </ul>	
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+
+@Component({})
+
+export default class HeaderMenu extends Vue {
+
+  public lang: string = this.$store.state.language
+  private menuEng: Array<string> = ['SNUCSE','Account','Support','AppCenter','Dpt','Bacchus','help','한국어']
+  private menuKor: Array<string> = ['스누씨','통합계정','실습지원','앱센터','학부','바쿠스','도움말','English']
+  private menuSel: Array<string> = this.menuKor
+  private active: Array<boolean> = this.$store.state.menu
+
+  changeLang() {
+    this.$store.commit('changeLang')
+    if (this.$store.state.language === 'ko') this.menuSel = this.menuKor
+    else this.menuSel = this.menuEng
+  }
+
+  selectMenu(num) {
+    this.$store.commit('selectMenu', num)
+    this.active = this.$store.state.menu
+    var navs = document.getElementsByName("nav")
+    for (var i=0; i<this.active.length-1; i++){
+      if (this.active[i]==true) navs[i].className = "isActive"
+      else navs[i].className = "limenu"
+    }
+  }
+}
+</script>
+
+<style scoped>
+.ulhead {
+  list-style-type: none;
+  margin: 0;
+  overflow: hidden;
+  background-color: white;
+  padding: 0;
+  text-align: center;
+}
+.isActive {
+  float: left;
+}
+.isActive a {
+  display: block;
+  color: black;
+  font-size: 20px;
+  padding: 16px 16px 10px 16px;
+  text-decoration: none;
+  margin: 0 20px;
+  border-bottom: 2px solid orange;  
+}
+.limenu {
+  float: left;
+}
+.limenu a {
+  display: block;
+  color: black;
+  font-size: 20px;
+  padding: 14px 16px;
+  text-decoration: none;
+  margin: 0 20px;
+  border-radius: 4px;
+}
+.limenu a:hover {
+  background-color: #f2a43e;
+}
+.selmenu a {
+  display: block;
+  color: black;
+  font-size: 20px;
+  padding: 14px 16px;
+  text-decoration: none;
+  margin: 0 20px;
+  border-radius: 4px;
+  background-color: #f2a43e;
+}
+.lilink {
+  float: left;
+}
+.lilink a {
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  font-size: 16px;
+  color: rgb(255, 123, 0);
+  padding: 16px 16px;
+  margin: 0 8px;
+}
+.lilink a:hover {
+  color: #f2a43e;
+}
+.libutton {
+  float: right;
+}
+.libutton button {
+  background-color: white;
+  padding: 16px 18px;
+  border: none;
+  color: black;
+  display: block;
+  font-size: 20px;
+}
+.libutton button:hover {
+  background-color: #f2a43e;
+}
+</style>

--- a/front/components/LabSupport.vue
+++ b/front/components/LabSupport.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+  실습 지원 
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+
+@Component({})
+
+export default class LabSupport extends Vue {
+
+}
+</script>

--- a/front/components/LoginForm.vue
+++ b/front/components/LoginForm.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="login">
+  <h2> {{menuSel[0]}} </h2>
+  <el-form>
+    <el-form-item label="username">
+      <el-input v-model="username" size="small"/>
+    </el-form-item>
+    <el-form-item label="password">
+      <el-input v-model="password" size="small"/>
+    </el-form-item>
+    <el-form-item>
+      <el-button class="button" type="primary" @click="onLogin"> {{menuSel[1]}} </el-button>
+    </el-form-item>
+  </el-form>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+
+export default class LoginForm extends Vue {
+
+  public username: string = ''
+  public password: string = ''
+  private menuEng: Array<string> = ['Please login to manage your integrated account','Login']
+  private menuKor: Array<string> = ['통합 계정 관리를 위해 로그인하십시오.','로그인 ']
+
+  get menuSel() {
+    return (this.lang === 'ko') ? this.menuKor : this.menuEng
+  }
+  get lang() {
+    return this.$store.state.language
+  }
+
+  async onLogin() {
+    if (!this.username || !this.password) {
+      this.$notify.error('Field error!')
+      return      
+    }
+  }
+
+}
+</script>
+
+<style scoped>
+.el-form {
+  margin-top: 50px;
+}
+.login {
+  width: 400px;
+  height: 380px;
+  margin-top: 8%;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  vertical-align: middle;
+}
+.button {
+  margin-top: 20px;
+  width: 120px;
+  height: 30px;
+  padding: 3px;
+  background-color: white;
+  border: 2px solid #f2a43e;
+  color: black;
+}
+.button:hover {
+  background-color: #f2a43e;
+}
+</style>

--- a/front/components/ServiceInfo.vue
+++ b/front/components/ServiceInfo.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+  도움말
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+
+@Component({})
+
+export default class ServiceInfo extends Vue {
+
+}
+</script>

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -1,5 +1,27 @@
 <template>
   <div>
-    <nuxt/>
+    <el-container>
+      <el-header>
+        <header-menu/>
+      </el-header>
+      <el-main>
+        <nuxt/>
+      </el-main>
+    </el-container>
   </div>
 </template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import HeaderMenu from '~/components/HeaderMenu.vue'
+
+@Component({
+  components: {
+    'header-menu': HeaderMenu,
+  }
+})
+
+export default class extends Vue {
+  
+}
+</script>

--- a/front/pages/admin.vue
+++ b/front/pages/admin.vue
@@ -1,20 +1,20 @@
 <template>
   <div>
-    <login-form/>
+    <user-admin-table/>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-import LoginForm from '~/components/LoginForm.vue'
+import UserAdminTable from '~/components/UserAdminTable.vue'
 
 @Component({
   components: {
-    'login-form': LoginForm,
+    'user-admin-table': UserAdminTable,
   }
 })
 
-export default class extends Vue {
+export default class admin extends Vue {
 
 }
 </script>

--- a/front/pages/appcenter.vue
+++ b/front/pages/appcenter.vue
@@ -1,20 +1,20 @@
 <template>
   <div>
-    <login-form/>
+    <app-center/>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-import LoginForm from '~/components/LoginForm.vue'
+import AppCenter from '~/components/AppCenter.vue'
 
 @Component({
   components: {
-    'login-form': LoginForm,
+    'app-center': AppCenter,
   }
 })
 
-export default class extends Vue {
+export default class appcenter extends Vue {
 
 }
 </script>

--- a/front/pages/help.vue
+++ b/front/pages/help.vue
@@ -1,20 +1,20 @@
 <template>
   <div>
-    <login-form/>
+    <service-info/>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-import LoginForm from '~/components/LoginForm.vue'
+import ServiceInfo from '~/components/ServiceInfo.vue'
 
 @Component({
   components: {
-    'login-form': LoginForm,
+    'service-info': ServiceInfo,
   }
 })
 
-export default class extends Vue {
+export default class help extends Vue {
 
 }
 </script>

--- a/front/pages/support.vue
+++ b/front/pages/support.vue
@@ -1,20 +1,20 @@
 <template>
   <div>
-    <login-form/>
+    <lab-support/>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-import LoginForm from '~/components/LoginForm.vue'
+import LabSupport from '~/components/LabSupport.vue'
 
 @Component({
   components: {
-    'login-form': LoginForm,
+    'lab-support': LabSupport,
   }
 })
 
-export default class extends Vue {
+export default class support extends Vue {
 
 }
 </script>

--- a/front/store/index.ts
+++ b/front/store/index.ts
@@ -1,0 +1,23 @@
+export const state = () => ({
+  language: 'ko',
+  menu: [true, false, false, false] //caution : number of menus fixed as 4
+})
+
+export const mutations = {
+  changeLang(state) {
+    if (state.language === 'ko') {
+      state.language = 'en'
+    }
+    else {
+      state.language = 'ko'
+    }
+  },
+  selectMenu(state, selected) {
+    for (var i=0; i<state.menu.length; i++){
+      state.menu[i] = false
+    }
+    state.menu[selected] = true
+  }
+}
+
+


### PR DESCRIPTION
## Pages
|route|component|
|-----|------------|
|/|LoginForm|
|/admin|UserAdminTable|
|/support|LabSupport|
|/appcenter|AppCenter|
|/help|ServiceInfo|

## Layout
default layout에 HeaderMenu component를 넣었습니다.

## Store
language랑 menu 저장하는 방법을 잘 몰라서 store에 약간 하드코딩해서 넣었습니다.
persistent는 아니어서 refresh하면 설정 유지가 안됩니다.

## Link
스누씨, 학부, 바쿠스 링크 연결해놓았습니다.

## Capture

### index.vue

![2018-08-13 5 04 36](https://user-images.githubusercontent.com/37061052/44020737-cf6471b8-9f1d-11e8-8972-63bc02b1bb12.png)

### support.vue

underline은 선택된 것이고 background color 바뀐 것은 hover입니다.

![2018-08-13 5 04 48](https://user-images.githubusercontent.com/37061052/44020739-d0cab4fe-9f1d-11e8-9fda-ab08417ad9c0.png)

### index.vue (english)

메뉴 이름이랑 안내 하드코딩해서 한/영 전환하게 했습니다.

![2018-08-13 5 04 55](https://user-images.githubusercontent.com/37061052/44020742-d1cee122-9f1d-11e8-9456-0e2aaac2ef67.png)

## Possible Problems
* refresh 하면 설정 사라짐
* css 잘 몰라서 폰이나 IE에서는 어떻게 보일지 모르겠어요.