### PR TITLE
계정 생성과 동시에 posix uid assign

### DIFF
--- a/core/config.json.example
+++ b/core/config.json.example
@@ -39,7 +39,6 @@
     "sudoerGroupGid": 100600,
     "defaultShell": "/bin/bash",
     "minUid": 100000,
-    "nullUid": 99999,
     "homeDirectoryPrefix": "/csehome"
   },
   "postgresql": {

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -37,7 +37,7 @@ create table users (
   name text not null check (name <> ''),
 
   -- posixAccount
-  uid integer unique,
+  uid integer unique not null,
   shell text not null references shells(shell),
 
   -- Language preference

--- a/core/src/config.ts
+++ b/core/src/config.ts
@@ -186,8 +186,6 @@ export interface PosixConfig {
    */
   minUid: number
 
-  nullUid: number
-
   /**
    * Prefix for home directory.
    */

--- a/core/src/ldap/server.ts
+++ b/core/src/ldap/server.ts
@@ -71,14 +71,8 @@ const createServer = (options: ldap.ServerOptions, model: Model, config: Config)
     const cn = req.dn.rdns[0].attrs.cn.value
     try {
       const userIdx = await model.pgDo(c => model.users.authenticate(c, cn, req.credentials))
-      if (await model.pgDo(c => model.users.assignUid(c, userIdx, config.posix.minUid))) {
-        // assigned uid
-        // user must log in again
-        return next(new ldap.InvalidCredentialsError())
-      } else {
-        res.end()
-        return next()
-      }
+      res.end()
+      return next()
     } catch (e) {
       if (e instanceof AuthenticationError) {
         return next(new ldap.InvalidCredentialsError())

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -153,7 +153,7 @@ export default class Users {
     await client.query('LOCK TABLE users IN ACCESS EXCLUSIVE MODE')
     const getNewUidResult = await client.query('SELECT b.uid + 1 AS uid FROM users AS a RIGHT OUTER JOIN ' +
       'users AS b ON a.uid = b.uid + 1 WHERE a.uid IS NULL AND b.uid + 1 >= $1 ORDER BY b.uid LIMIT 1', [minUid])
-    return getNewUidResult.rows.length ? getNewUidResult.rows[0].uid : minUid;
+    return getNewUidResult.rows.length ? getNewUidResult.rows[0].uid : minUid
   }
 
   public async generatePasswordChangeToken(client: PoolClient, userIdx: number): Promise<string> {

--- a/core/test/model/users.test.ts
+++ b/core/test/model/users.test.ts
@@ -232,8 +232,8 @@ test('legacy mssql password (sha512)', async t => {
     hash: Buffer.from('CF413665AC3A350E2F61EF6A8845B729CE771DD70E3FA2808C0F24CE3945A19A43F160087' +
       '60ED06D7AF5181986AC39563CE1356BA451468BD27F936FF5D1BAA9', 'hex')})
   await model.pgDo(async c => {
-    const result = await c.query('INSERT INTO users (username, password_digest, name, shell, preferred_language)' +
-      'VALUES ($1, $2, \'OLDoge\', \'/bin/bash\', \'en\') RETURNING idx', [username, legacyPasswordDigest])
+    const result = await c.query('INSERT INTO users (username, password_digest, name, uid, shell, preferred_language)' +
+      'VALUES ($1, $2, \'OLDoge\', 10, \'/bin/bash\', \'en\') RETURNING idx', [username, legacyPasswordDigest])
     const userIdx = result.rows[0].idx
     // doge should be able to login using password stored in old doggy password format
     await model.users.authenticate(c, username, password)


### PR DESCRIPTION
Changes:

* 모든 계정에 고유한 posix uid가 부여되도록 강제합니다
* 따라서 계정 생성과 동시에 posix uid가 발급됩니다

Remarks:

* 현재 실제 DB에는 uid가 null인 계정이 있으므로 별도의 스크립트를 통해 이를 교정해야 합니다.
* 사용되지 않은 uid를 reclaim하는 방법에 대해서는 추후 논의합니다.

Resolves #69