### PR TITLE
Deadlock avoidance for access exclusive & advisory locks

### DIFF
--- a/core/src/api/handlers/emails.ts
+++ b/core/src/api/handlers/emails.ts
@@ -35,14 +35,14 @@ export function sendVerificationEmail(model: Model, config: Config): IMiddleware
 
     try {
       // create email address and generate token
-      await model.pgDo(async c => {
-        emailIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-        const isValidated = await model.emailAddresses.isValidatedEmail(c, emailIdx)
+      await model.pgDo(async tr => {
+        emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+        const isValidated = await model.emailAddresses.isValidatedEmail(tr, emailIdx)
         if (isValidated) {
           throw new Error('already validated')
         }
-        token = await model.emailAddresses.generateVerificationToken(c, emailIdx)
-        resendCount = await model.emailAddresses.getResendCount(c, token)
+        token = await model.emailAddresses.generateVerificationToken(tr, emailIdx)
+        resendCount = await model.emailAddresses.getResendCount(tr, token)
       })
     } catch (e) {
       ctx.status = 400
@@ -87,9 +87,9 @@ export function checkVerificationEmailToken(model: Model): IMiddleware {
     let result
 
     try {
-      await model.pgDo(async c => {
-        emailAddress = await model.emailAddresses.getEmailAddressByToken(c, token)
-        await model.emailAddresses.ensureTokenNotExpired(c, token)
+      await model.pgDo(async tr => {
+        emailAddress = await model.emailAddresses.getEmailAddressByToken(tr, token)
+        await model.emailAddresses.ensureTokenNotExpired(tr, token)
         result = {
           emailLocal: emailAddress.local,
           emailDomain: emailAddress.domain,

--- a/core/src/api/handlers/login.ts
+++ b/core/src/api/handlers/login.ts
@@ -16,9 +16,9 @@ export function login(model: Model): IMiddleware {
     let userIdx: number
 
     try {
-      await model.pgDo(async c => {
+      await model.pgDo(async tr => {
         try {
-          userIdx = await model.users.authenticate(c, username, password)
+          userIdx = await model.users.authenticate(tr, username, password)
 
           if (ctx.session) {
             // store information in session store
@@ -70,9 +70,9 @@ export function loginLegacy(model: Model): IMiddleware {
     let userIdx: number
 
     try {
-      await model.pgDo(async c => {
+      await model.pgDo(async tr => {
         try {
-          userIdx = await model.users.authenticate(c, username, password)
+          userIdx = await model.users.authenticate(tr, username, password)
         } catch (e) {
           ctx.status = 200
           throw e

--- a/core/src/api/handlers/shells.ts
+++ b/core/src/api/handlers/shells.ts
@@ -4,8 +4,8 @@ import { IMiddleware } from 'koa-router'
 export function getShells(model: Model): IMiddleware {
   return async (ctx, next) => {
     let shells
-    await model.pgDo(async c => {
-      shells = await model.shells.getShells(c)
+    await model.pgDo(async tr => {
+      shells = await model.shells.getShells(tr)
     })
 
     ctx.status = 200

--- a/core/src/api/handlers/users.ts
+++ b/core/src/api/handlers/users.ts
@@ -31,8 +31,8 @@ export function createUser(model: Model, config: Config): IMiddleware {
 
     // check verification token
     try {
-      await model.pgDo(async c => {
-        emailAddress = await model.emailAddresses.getEmailAddressByToken(c, token)
+      await model.pgDo(async tr => {
+        emailAddress = await model.emailAddresses.getEmailAddressByToken(tr, token)
       })
     } catch (e) {
       ctx.status = 401
@@ -64,14 +64,14 @@ export function createUser(model: Model, config: Config): IMiddleware {
     }
 
     try {
-      await model.pgDo(async c => {
-        const emailAddressIdx = await model.emailAddresses.getIdxByAddress(c, emailAddress.local, emailAddress.domain)
+      await model.pgDo(async tr => {
+        const emailAddressIdx = await model.emailAddresses.getIdxByAddress(tr, emailAddress.local, emailAddress.domain)
         const userIdx = await model.users.create(
-          c, username, password, name, config.posix.defaultShell, preferredLanguage)
-        await model.emailAddresses.validate(c, userIdx, emailAddressIdx)
-        await model.emailAddresses.removeToken(c, token)
+          tr, username, password, name, config.posix.defaultShell, preferredLanguage)
+        await model.emailAddresses.validate(tr, userIdx, emailAddressIdx)
+        await model.emailAddresses.removeToken(tr, token)
         // Make user state pending by deactivating user
-        await model.users.deactivate(c, userIdx)
+        await model.users.deactivate(tr, userIdx)
 
         const validateStudentNumber = (snuid: string) => {
           const regexList = [
@@ -89,7 +89,7 @@ export function createUser(model: Model, config: Config): IMiddleware {
 
         for (const studentNumber of studentNumbers) {
           validateStudentNumber(studentNumber)
-          await model.users.addStudentNumber(c, userIdx, studentNumber)
+          await model.users.addStudentNumber(tr, userIdx, studentNumber)
         }
 
         try {
@@ -142,10 +142,10 @@ export function sendChangePasswordEmail(model: Model, config: Config): IMiddlewa
     let token = ''
     let resendCount = -1
     try {
-      await model.pgDo(async c => {
-        const userIdx = await model.users.getUserIdxByEmailAddress(c, emailLocal, emailDomain)
-        token = await model.users.generatePasswordChangeToken(c, userIdx)
-        resendCount = await model.users.getResendCount(c, token)
+      await model.pgDo(async tr => {
+        const userIdx = await model.users.getUserIdxByEmailAddress(tr, emailLocal, emailDomain)
+        token = await model.users.generatePasswordChangeToken(tr, userIdx)
+        resendCount = await model.users.getResendCount(tr, token)
       })
     } catch (e) {
       // no such entry, but do nothing and just return 200
@@ -204,15 +204,15 @@ export function changePassword(model: Model): IMiddleware {
 
     try {
       // check token validity
-      await model.pgDo(async c => {
-        const userIdx = await model.users.getUserIdxByPasswordToken(c, token)
-        await model.users.ensureTokenNotExpired(c, token)
-        const user = await model.users.getByUserIdx(c, userIdx)
+      await model.pgDo(async tr => {
+        const userIdx = await model.users.getUserIdxByPasswordToken(tr, token)
+        await model.users.ensureTokenNotExpired(tr, token)
+        const user = await model.users.getByUserIdx(tr, userIdx)
         if (user.username === null) {
           throw new Error()
         }
-        await model.users.changePassword(c, userIdx, newPassword)
-        await model.users.removeToken(c, token)
+        await model.users.changePassword(tr, userIdx, newPassword)
+        await model.users.removeToken(tr, token)
       })
     } catch (e) {
       ctx.status = 401
@@ -236,8 +236,8 @@ export function getUserShell(model: Model): IMiddleware {
 
     let shell: string = ''
     try {
-      await model.pgDo(async c => {
-        shell = await model.users.getShell(c, userIdx)
+      await model.pgDo(async tr => {
+        shell = await model.users.getShell(tr, userIdx)
       })
     } catch (e) {
       ctx.status = 400
@@ -276,8 +276,8 @@ export function changeUserShell(model: Model): IMiddleware {
     }
 
     try {
-      await model.pgDo(async c => {
-        await model.users.changeShell(c, userIdx, shell)
+      await model.pgDo(async tr => {
+        await model.users.changeShell(tr, userIdx, shell)
       })
     } catch (e) {
       ctx.status = 400
@@ -301,8 +301,8 @@ export function getUserEmails(model: Model): IMiddleware {
 
     let ownerIdx: any
     try {
-      await model.pgDo(async c => {
-        const owner = await model.users.getByUsername(c, username)
+      await model.pgDo(async tr => {
+        const owner = await model.users.getByUsername(tr, username)
         ownerIdx = owner.idx
       })
     } catch (e) {
@@ -316,8 +316,8 @@ export function getUserEmails(model: Model): IMiddleware {
     }
 
     let emails
-    await model.pgDo(async c => {
-      emails = await model.emailAddresses.getEmailsByOwnerIdx(c, ownerIdx)
+    await model.pgDo(async tr => {
+      emails = await model.emailAddresses.getEmailsByOwnerIdx(tr, ownerIdx)
     })
 
     ctx.status = 200

--- a/core/src/api/handlers/users.ts
+++ b/core/src/api/handlers/users.ts
@@ -64,6 +64,7 @@ export function createUser(model: Model, config: Config): IMiddleware {
     }
 
     try {
+      // acquires access exclusive lock on 'users'
       await model.pgDo(async tr => {
         const emailAddressIdx = await model.emailAddresses.getIdxByAddress(tr, emailAddress.local, emailAddress.domain)
         const userIdx = await model.users.create(
@@ -105,7 +106,7 @@ export function createUser(model: Model, config: Config): IMiddleware {
         } catch (e) {
           model.log.warn(`No slack notification sent for: ${username}`)
         }
-      })
+      }, ['users'])
     } catch (e) {
       ctx.status = 400
       return

--- a/core/src/ldap/server.ts
+++ b/core/src/ldap/server.ts
@@ -70,7 +70,7 @@ const createServer = (options: ldap.ServerOptions, model: Model, config: Config)
     }
     const cn = req.dn.rdns[0].attrs.cn.value
     try {
-      const userIdx = await model.pgDo(c => model.users.authenticate(c, cn, req.credentials))
+      const userIdx = await model.pgDo(tr => model.users.authenticate(tr, cn, req.credentials))
       res.end()
       return next()
     } catch (e) {
@@ -110,7 +110,7 @@ const createServer = (options: ldap.ServerOptions, model: Model, config: Config)
       } else {
         // Same results for 'one' and 'sub'
         // TODO: do not assign uid if the user is not capable to sign in to the LDAP host.
-        (await model.pgDo(c => model.users.getAllAsPosixAccounts(c))).forEach(account => {
+        (await model.pgDo(tr => model.users.getAllAsPosixAccounts(tr))).forEach(account => {
           if (req.filter.matches(account.attributes)) {
             res.send(account)
           }
@@ -120,7 +120,7 @@ const createServer = (options: ldap.ServerOptions, model: Model, config: Config)
       if (parentDN.equals(parsedUsersDN)) {
         const wantedUid = req.dn.rdns[0].attrs.cn.value
         try {
-          const user = await model.pgDo(c => model.users.getByUsernameAsPosixAccount(c, wantedUid))
+          const user = await model.pgDo(tr => model.users.getByUsernameAsPosixAccount(tr, wantedUid))
           res.send(user)
         } catch (e) {
           if (!(e instanceof NoSuchEntryError)) {

--- a/core/src/model/email_addresses.ts
+++ b/core/src/model/email_addresses.ts
@@ -15,7 +15,7 @@ export default class EmailAddresses {
 
   /**
    * Create an email address record.
-   * @param client provides access to the database
+   * @param tr provides access to the database
    * @param local local part of the address
    * @param domain domain part of the address
    * @return promise of the index of the new record
@@ -56,7 +56,7 @@ export default class EmailAddresses {
   }
 
   public async generateVerificationToken(tr: Transaction, emailIdx: number): Promise<string> {
-    await this.resetResendCountIfExpired(client, emailIdx)
+    await this.resetResendCountIfExpired(tr, emailIdx)
     const query = 'INSERT INTO email_verification_tokens AS e(email_idx, token, expires) VALUES ($1, $2, $3) ' +
     'ON CONFLICT (email_idx) DO UPDATE SET token = $2, resend_count = e.resend_count + 1, expires = $3'
     const randomBytes = await this.asyncRandomBytes(32)

--- a/core/src/model/groups.ts
+++ b/core/src/model/groups.ts
@@ -1,6 +1,6 @@
 import Model from './model'
 import { Translation } from './translation'
-import { PoolClient } from 'pg'
+import Transaction from './transaction'
 import { NoSuchEntryError } from './errors'
 
 export interface Group {
@@ -24,17 +24,17 @@ export default class Groups {
   constructor(private readonly model: Model) {
   }
 
-  public async create(client: PoolClient, name: Translation, description: Translation): Promise<number> {
+  public async create(tr: Transaction, name: Translation, description: Translation): Promise<number> {
     const query = 'INSERT INTO groups(name_ko, name_en, description_ko, ' +
       'description_en) VALUES ($1, $2, $3, $4) RETURNING idx'
-    const result = await client.query(query, [name.ko, name.en, description.ko, description.en])
+    const result = await tr.query(query, [name.ko, name.en, description.ko, description.en])
     await this.updateGroupReachableCache(client)
     return result.rows[0].idx
   }
 
-  public async delete(client: PoolClient, groupIdx: number): Promise<number> {
+  public async delete(tr: Transaction, groupIdx: number): Promise<number> {
     const query = 'DELETE FROM groups WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [groupIdx])
+    const result = await tr.query(query, [groupIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -42,48 +42,48 @@ export default class Groups {
     return result.rows[0].idx
   }
 
-  public async getGroupReachableArray(client: PoolClient, groupIdx: number): Promise<Array<number>> {
+  public async getGroupReachableArray(tr: Transaction, groupIdx: number): Promise<Array<number>> {
     const query = 'SELECT subgroup_idx FROM group_reachable_cache WHERE supergroup_idx = $1'
-    const result = await client.query(query, [groupIdx])
+    const result = await tr.query(query, [groupIdx])
     return result.rows.map(row => row.subgroup_idx)
   }
 
-  public async getByIdx(client: PoolClient, idx: number): Promise<Group> {
+  public async getByIdx(tr: Transaction, idx: number): Promise<Group> {
     const query = 'SELECT * FROM groups WHERE idx = $1'
-    const result = await client.query(query, [idx])
+    const result = await tr.query(query, [idx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return this.rowToGroup(result.rows[0])
   }
 
-  public async setOwnerUser(client: PoolClient, groupIdx: number, ownerUserIdx: number | null): Promise<void> {
+  public async setOwnerUser(tr: Transaction, groupIdx: number, ownerUserIdx: number | null): Promise<void> {
     const query = 'UPDATE groups SET owner_user_idx = $1 WHERE idx = $2 RETURNING idx'
-    const result = await client.query(query, [ownerUserIdx, groupIdx])
+    const result = await tr.query(query, [ownerUserIdx, groupIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
   }
 
-  public async setOwnerGroup(client: PoolClient, groupIdx: number, ownerGroupIdx: number | null): Promise<void> {
+  public async setOwnerGroup(tr: Transaction, groupIdx: number, ownerGroupIdx: number | null): Promise<void> {
     const query = 'UPDATE groups SET owner_group_idx = $1 WHERE idx = $2 RETURNING idx'
-    const result = await client.query(query, [ownerGroupIdx, groupIdx])
+    const result = await tr.query(query, [ownerGroupIdx, groupIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
   }
 
-  public async addGroupRelation(client: PoolClient, supergroupIdx: number, subgroupIdx: number): Promise<number> {
+  public async addGroupRelation(tr: Transaction, supergroupIdx: number, subgroupIdx: number): Promise<number> {
     const query = 'INSERT INTO group_relations(supergroup_idx, subgroup_idx) ' +
       'VALUES ($1, $2) RETURNING idx'
-    const result = await client.query(query, [supergroupIdx, subgroupIdx])
+    const result = await tr.query(query, [supergroupIdx, subgroupIdx])
     await this.updateGroupReachableCache(client)
     return result.rows[0].idx
   }
 
-  public async deleteGroupRelation(client: PoolClient, groupRelationIdx: number): Promise<number> {
+  public async deleteGroupRelation(tr: Transaction, groupRelationIdx: number): Promise<number> {
     const query = 'DELETE FROM group_relations WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [groupRelationIdx])
+    const result = await tr.query(query, [groupRelationIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -91,9 +91,9 @@ export default class Groups {
     return result.rows[0].idx
   }
 
-  private async getAllGroupRelation(client: PoolClient): Promise<Array<GroupRelationship>> {
+  private async getAllGroupRelation(tr: Transaction): Promise<Array<GroupRelationship>> {
     const query = 'SELECT supergroup_idx, subgroup_idx FROM group_relations'
-    const result = await client.query(query)
+    const result = await tr.query(query)
     return result.rows.map(row => this.rowToGroupRelation(row))
   }
 
@@ -116,21 +116,21 @@ export default class Groups {
     return cache[groupIdx]
   }
 
-  private async getAllIdx(client: PoolClient): Promise<Array<number>> {
+  private async getAllIdx(tr: Transaction): Promise<Array<number>> {
     const query = 'SELECT idx FROM groups'
-    const result = await client.query(query)
+    const result = await tr.query(query)
 
     return result.rows.map(row => row.idx)
   }
 
-  private async updateGroupReachableCache(client: PoolClient): Promise<void> {
+  private async updateGroupReachableCache(tr: Transaction): Promise<void> {
     let groupIdxArray: Array<number> = []
     let groupRelationArray: Array<GroupRelationship> = []
     const firstGroupReachable: GroupReachable = {}
     const cache: GroupReachable = {}
 
     // this will acquire ACCESS EXCLUSIVE lock for cache table
-    await client.query('TRUNCATE group_reachable_cache')
+    await tr.query('TRUNCATE group_reachable_cache')
 
     // these queries should be executed AFTER acquiring lock
     groupIdxArray = await this.getAllIdx(client)
@@ -156,7 +156,7 @@ export default class Groups {
     for (const supergroupIdx of Object.keys(cache)) {
       for (const subgroupIdx of cache[Number(supergroupIdx)]) {
         const query = 'INSERT INTO group_reachable_cache(supergroup_idx, subgroup_idx) VALUES ($1, $2)'
-        await client.query(query, [Number(supergroupIdx), Number(subgroupIdx)])
+        await tr.query(query, [Number(supergroupIdx), Number(subgroupIdx)])
       }
     }
   }

--- a/core/src/model/groups.ts
+++ b/core/src/model/groups.ts
@@ -130,6 +130,7 @@ export default class Groups {
     const cache: GroupReachable = {}
 
     // this will acquire ACCESS EXCLUSIVE lock for cache table
+    tr.ensureHasAccessExclusiveLock('group_reachable_cache')
     await tr.query('TRUNCATE group_reachable_cache')
 
     // these queries should be executed AFTER acquiring lock

--- a/core/src/model/groups.ts
+++ b/core/src/model/groups.ts
@@ -129,8 +129,8 @@ export default class Groups {
     const firstGroupReachable: GroupReachable = {}
     const cache: GroupReachable = {}
 
-    // this will acquire ACCESS EXCLUSIVE lock for cache table
     tr.ensureHasAccessExclusiveLock('group_reachable_cache')
+    // this will acquire ACCESS EXCLUSIVE lock for cache table
     await tr.query('TRUNCATE group_reachable_cache')
 
     // these queries should be executed AFTER acquiring lock

--- a/core/src/model/groups.ts
+++ b/core/src/model/groups.ts
@@ -28,7 +28,7 @@ export default class Groups {
     const query = 'INSERT INTO groups(name_ko, name_en, description_ko, ' +
       'description_en) VALUES ($1, $2, $3, $4) RETURNING idx'
     const result = await tr.query(query, [name.ko, name.en, description.ko, description.en])
-    await this.updateGroupReachableCache(client)
+    await this.updateGroupReachableCache(tr)
     return result.rows[0].idx
   }
 
@@ -38,7 +38,7 @@ export default class Groups {
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
-    await this.updateGroupReachableCache(client)
+    await this.updateGroupReachableCache(tr)
     return result.rows[0].idx
   }
 
@@ -77,7 +77,7 @@ export default class Groups {
     const query = 'INSERT INTO group_relations(supergroup_idx, subgroup_idx) ' +
       'VALUES ($1, $2) RETURNING idx'
     const result = await tr.query(query, [supergroupIdx, subgroupIdx])
-    await this.updateGroupReachableCache(client)
+    await this.updateGroupReachableCache(tr)
     return result.rows[0].idx
   }
 
@@ -87,7 +87,7 @@ export default class Groups {
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
-    await this.updateGroupReachableCache(client)
+    await this.updateGroupReachableCache(tr)
     return result.rows[0].idx
   }
 
@@ -133,8 +133,8 @@ export default class Groups {
     await tr.query('TRUNCATE group_reachable_cache')
 
     // these queries should be executed AFTER acquiring lock
-    groupIdxArray = await this.getAllIdx(client)
-    groupRelationArray = await this.getAllGroupRelation(client)
+    groupIdxArray = await this.getAllIdx(tr)
+    groupRelationArray = await this.getAllGroupRelation(tr)
 
     groupIdxArray.forEach(groupIdx => {
       firstGroupReachable[groupIdx] = []

--- a/core/src/model/model.ts
+++ b/core/src/model/model.ts
@@ -7,6 +7,7 @@ import Shells from './shells'
 import * as Bunyan from 'bunyan'
 import { ControllableError } from './errors'
 import Config from '../config'
+import Transaction from './transaction'
 
 export default class Model {
   public readonly users: Users
@@ -29,10 +30,26 @@ export default class Model {
     this.shells = new Shells(this)
   }
 
-  public async pgDo<T>(query: (client: pg.PoolClient) => Promise<T>): Promise<T> {
+  /**
+   * Execute queires in a new transaction.
+   * @param query lambda that executes queries
+   * @param accessExclusiveLockTables tables that require stronger isolation than 'read committed' model
+   * @param advisoryLockKeys keys for acquiring advisory locks before executing queries
+   */
+  public async pgDo<T>(query: (client: pg.PoolClient) => Promise<T>,
+      accessExclusiveLockTables?: Array<string>, advisoryLockKeys?: Array<number>): Promise<T> {
     const client = await this.pgPool.connect()
+    const lockTables = accessExclusiveLockTables ? accessExclusiveLockTables.sort() : []
+    const lockKeys = advisoryLockKeys ? advisoryLockKeys.sort() : []
+    const transaction = new Transaction(client, lockTables, lockKeys)
     try {
       await client.query('BEGIN')
+      for (const key of lockKeys) {
+        await client.query('SELECT pg_advisory_xact_lock($1)', [key])
+      }
+      for (const table of lockTables) {
+        await client.query('LOCK TABLE $1 IN ACCESS EXCLUSIVE MODE', [table])
+      }
       const result = await query(client)
       await client.query('COMMIT')
       return result

--- a/core/src/model/model.ts
+++ b/core/src/model/model.ts
@@ -51,6 +51,7 @@ export default class Model {
         await client.query(`LOCK TABLE ${table} IN ACCESS EXCLUSIVE MODE`)
       }
       const result = await query(transaction)
+      transaction.terminate()
       await client.query('COMMIT')
       return result
     } catch (e) {

--- a/core/src/model/model.ts
+++ b/core/src/model/model.ts
@@ -48,7 +48,7 @@ export default class Model {
         await client.query('SELECT pg_advisory_xact_lock($1)', [key])
       }
       for (const table of lockTables) {
-        await client.query('LOCK TABLE $1 IN ACCESS EXCLUSIVE MODE', [table])
+        await client.query(`LOCK TABLE ${table} IN ACCESS EXCLUSIVE MODE`)
       }
       const result = await query(transaction)
       await client.query('COMMIT')

--- a/core/src/model/model.ts
+++ b/core/src/model/model.ts
@@ -36,7 +36,7 @@ export default class Model {
    * @param accessExclusiveLockTables tables that require stronger isolation than 'read committed' model
    * @param advisoryLockKeys keys for acquiring advisory locks before executing queries
    */
-  public async pgDo<T>(query: (client: pg.PoolClient) => Promise<T>,
+  public async pgDo<T>(query: (transaction: Transaction) => Promise<T>,
       accessExclusiveLockTables?: Array<string>, advisoryLockKeys?: Array<number>): Promise<T> {
     const client = await this.pgPool.connect()
     const lockTables = accessExclusiveLockTables ? accessExclusiveLockTables.sort() : []
@@ -50,7 +50,7 @@ export default class Model {
       for (const table of lockTables) {
         await client.query('LOCK TABLE $1 IN ACCESS EXCLUSIVE MODE', [table])
       }
-      const result = await query(client)
+      const result = await query(transaction)
       await client.query('COMMIT')
       return result
     } catch (e) {

--- a/core/src/model/permissions.ts
+++ b/core/src/model/permissions.ts
@@ -47,8 +47,8 @@ export default class Permissions {
   }
 
   public async checkUserHavePermission(tr: Transaction, userIdx: number, permissionIdx: number): Promise<boolean> {
-    const userReachableGroups = Array.from(await this.model.users.getUserReachableGroups(client, userIdx))
-    const permissionRequirements = await this.getAllPermissionRequirements(client, permissionIdx)
+    const userReachableGroups = Array.from(await this.model.users.getUserReachableGroups(tr, userIdx))
+    const permissionRequirements = await this.getAllPermissionRequirements(tr, permissionIdx)
 
     for (const pr of permissionRequirements) {
       if (!userReachableGroups.includes(pr)) {

--- a/core/src/model/permissions.ts
+++ b/core/src/model/permissions.ts
@@ -1,52 +1,52 @@
 import Model from './model'
 import { Translation } from './translation'
-import { PoolClient } from 'pg'
+import Transaction from './transaction'
 import { NoSuchEntryError } from './errors'
 
 export default class Permissions {
   constructor(private readonly model: Model) {
   }
 
-  public async create(client: PoolClient, name: Translation, description: Translation): Promise<number> {
+  public async create(tr: Transaction, name: Translation, description: Translation): Promise<number> {
     const query = 'INSERT INTO permissions(name_ko, name_en, description_ko, ' +
       'description_en) VALUES ($1, $2, $3, $4) RETURNING idx'
-    const result = await client.query(query, [name.ko, name.en, description.ko, description.en])
+    const result = await tr.query(query, [name.ko, name.en, description.ko, description.en])
     return result.rows[0].idx
   }
 
-  public async delete(client: PoolClient, permissionIdx: number): Promise<number> {
+  public async delete(tr: Transaction, permissionIdx: number): Promise<number> {
     const query = 'DELETE FROM permissions WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [permissionIdx])
+    const result = await tr.query(query, [permissionIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
   }
 
-  public async addPermissionRequirement(client: PoolClient, groupIdx: number,
+  public async addPermissionRequirement(tr: Transaction, groupIdx: number,
     permissionIdx: number): Promise<number> {
     const query = 'INSERT INTO permission_requirements(group_idx, permission_idx) ' +
       'VALUES ($1, $2) RETURNING idx'
-    const result = await client.query(query, [groupIdx, permissionIdx])
+    const result = await tr.query(query, [groupIdx, permissionIdx])
     return result.rows[0].idx
   }
 
-  public async deletePermissionRequirement(client: PoolClient, idx: number): Promise<number> {
+  public async deletePermissionRequirement(tr: Transaction, idx: number): Promise<number> {
     const query = 'DELETE FROM permission_requirements WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [idx])
+    const result = await tr.query(query, [idx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
   }
 
-  public async getAllPermissionRequirements(client: PoolClient, idx: number): Promise<Array<number>> {
+  public async getAllPermissionRequirements(tr: Transaction, idx: number): Promise<Array<number>> {
     const query = 'SELECT group_idx FROM permission_requirements WHERE permission_idx = $1'
-    const result = await client.query(query, [idx])
+    const result = await tr.query(query, [idx])
     return result.rows.map(row => row.group_idx)
   }
 
-  public async checkUserHavePermission(client: PoolClient, userIdx: number, permissionIdx: number): Promise<boolean> {
+  public async checkUserHavePermission(tr: Transaction, userIdx: number, permissionIdx: number): Promise<boolean> {
     const userReachableGroups = Array.from(await this.model.users.getUserReachableGroups(client, userIdx))
     const permissionRequirements = await this.getAllPermissionRequirements(client, permissionIdx)
 

--- a/core/src/model/shells.ts
+++ b/core/src/model/shells.ts
@@ -1,23 +1,23 @@
 import Model from './model'
-import { PoolClient } from 'pg'
+import Transaction from './transaction'
 
 export default class Shells {
   constructor(private readonly model: Model) {
   }
 
-  public async getShells(client: PoolClient): Promise<Array<string>> {
+  public async getShells(tr: Transaction): Promise<Array<string>> {
     const query = 'SELECT shell from shells'
-    const result = await client.query(query)
+    const result = await tr.query(query)
     return result.rows.map(row => row.shell)
   }
 
-  public async addShell(client: PoolClient, shell: string): Promise<void> {
+  public async addShell(tr: Transaction, shell: string): Promise<void> {
     const query = 'INSERT INTO shells(shell) VALUES ($1)'
-    const result = await client.query(query, [shell])
+    const result = await tr.query(query, [shell])
   }
 
-  public async removeShell(client: PoolClient, shell: string): Promise<void> {
+  public async removeShell(tr: Transaction, shell: string): Promise<void> {
     const query = 'DELETE FROM shells WHERE shell = $1'
-    const result = await client.query(query, [shell])
+    const result = await tr.query(query, [shell])
   }
 }

--- a/core/src/model/transaction.ts
+++ b/core/src/model/transaction.ts
@@ -26,7 +26,7 @@ export default class Transaction {
   public ensureHasAdvisoryLock(key: number) {
     this.ensureNotTerminated()
     if (!this.advisoryLockKeys.includes(key)) {
-      throw new Error(`Advisory lock on key '${key}' is required but missing`)
+      throw new Error(`Advisory lock on key ${key} is required but missing`)
     }
     this.ensuredAdvisoryLockKeys.add(key)
   }
@@ -36,7 +36,7 @@ export default class Transaction {
     this.terminated = true
     for (const table of this.accessExclusiveLockTables) {
       if (!this.ensuredAccessExclusiveLockTables.has(table)) {
-        throw new Error(`Unnecessary lock declaration for table ${table}`)
+        throw new Error(`Unnecessary lock declaration for table '${table}'`)
       }
     }
     for (const key of this.advisoryLockKeys) {

--- a/core/src/model/transaction.ts
+++ b/core/src/model/transaction.ts
@@ -1,0 +1,24 @@
+import * as pg from 'pg'
+
+export default class Transaction {
+  constructor(public readonly client: pg.PoolClient,
+      private readonly accessExclusiveLockTables: Array<string>,
+      private readonly advisoryLockKeys: Array<number>) {
+  }
+
+  public query(query: string, values?: Array<any>): Promise<pg.QueryResult> {
+    return this.client.query(query, values)
+  }
+
+  public ensureHasAccessExclusiveLock(table: string) {
+    if (!this.accessExclusiveLockTables.includes(table)) {
+      throw new Error(`AccessExclusiveLock on table '${table}' is required but missing`)
+    }
+  }
+
+  public ensureHasAdvisoryLock(key: number) {
+    if (!this.advisoryLockKeys.includes(key)) {
+      throw new Error(`Advisory lock on key '${key}' is required but missing`)
+    }
+  }
+}

--- a/core/src/model/transaction.ts
+++ b/core/src/model/transaction.ts
@@ -1,24 +1,54 @@
 import * as pg from 'pg'
 
 export default class Transaction {
+  private readonly ensuredAccessExclusiveLockTables: Set<string> = new Set()
+  private readonly ensuredAdvisoryLockKeys: Set<number> = new Set()
+  private terminated = false
+
   constructor(public readonly client: pg.PoolClient,
       private readonly accessExclusiveLockTables: Array<string>,
       private readonly advisoryLockKeys: Array<number>) {
   }
 
   public query(query: string, values?: Array<any>): Promise<pg.QueryResult> {
+    this.ensureNotTerminated()
     return this.client.query(query, values)
   }
 
   public ensureHasAccessExclusiveLock(table: string) {
+    this.ensureNotTerminated()
     if (!this.accessExclusiveLockTables.includes(table)) {
       throw new Error(`Access Exclusive lock on table '${table}' is required but missing`)
     }
+    this.ensuredAccessExclusiveLockTables.add(table)
   }
 
   public ensureHasAdvisoryLock(key: number) {
+    this.ensureNotTerminated()
     if (!this.advisoryLockKeys.includes(key)) {
       throw new Error(`Advisory lock on key '${key}' is required but missing`)
+    }
+    this.ensuredAdvisoryLockKeys.add(key)
+  }
+
+  public terminate() {
+    this.ensureNotTerminated()
+    this.terminated = true
+    for (const table of this.accessExclusiveLockTables) {
+      if (!this.ensuredAccessExclusiveLockTables.has(table)) {
+        throw new Error(`Unnecessary lock declaration for table ${table}`)
+      }
+    }
+    for (const key of this.advisoryLockKeys) {
+      if (!this.ensuredAdvisoryLockKeys.has(key)) {
+        throw new Error(`Unnecessary lock declaration for key ${key}`)
+      }
+    }
+  }
+
+  private ensureNotTerminated(): void {
+    if (this.terminated) {
+      throw new Error('Transaction terminated')
     }
   }
 }

--- a/core/src/model/transaction.ts
+++ b/core/src/model/transaction.ts
@@ -12,7 +12,7 @@ export default class Transaction {
 
   public ensureHasAccessExclusiveLock(table: string) {
     if (!this.accessExclusiveLockTables.includes(table)) {
-      throw new Error(`AccessExclusiveLock on table '${table}' is required but missing`)
+      throw new Error(`Access Exclusive lock on table '${table}' is required but missing`)
     }
   }
 

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -149,6 +149,7 @@ export default class Users {
   }
 
   public async generateUid(tr: Transaction): Promise<number> {
+    tr.ensureHasAccessExclusiveLock('users')
     const minUid = this.model.config.posix.minUid
     const getNewUidResult = await tr.query('SELECT b.uid + 1 AS uid FROM users AS a RIGHT OUTER JOIN ' +
       'users AS b ON a.uid = b.uid + 1 WHERE a.uid IS NULL AND b.uid + 1 >= $1 ORDER BY b.uid LIMIT 1', [minUid])

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -150,7 +150,6 @@ export default class Users {
 
   public async generateUid(client: PoolClient): Promise<number> {
     const minUid = this.model.config.posix.minUid
-    await client.query('LOCK TABLE users IN ACCESS EXCLUSIVE MODE')
     const getNewUidResult = await client.query('SELECT b.uid + 1 AS uid FROM users AS a RIGHT OUTER JOIN ' +
       'users AS b ON a.uid = b.uid + 1 WHERE a.uid IS NULL AND b.uid + 1 >= $1 ORDER BY b.uid LIMIT 1', [minUid])
     return getNewUidResult.rows.length ? getNewUidResult.rows[0].uid : minUid

--- a/core/src/model/users.ts
+++ b/core/src/model/users.ts
@@ -1,5 +1,5 @@
 import Model from './model'
-import { PoolClient } from 'pg'
+import Transaction from './transaction'
 import { NoSuchEntryError, AuthenticationError, NotActivatedError, ExpiredTokenError } from './errors'
 import * as argon2 from 'argon2'
 import * as phc from '@phc/format'
@@ -33,20 +33,20 @@ export default class Users {
     this.posixAccountsCache = null
   }
 
-  public async create(client: PoolClient, username: string, password: string,
+  public async create(tr: Transaction, username: string, password: string,
       name: string, shell: string, preferredLanguage: Language): Promise<number> {
     const query = 'INSERT INTO users(username, password_digest, name, uid, shell, preferred_language) ' +
       'VALUES ($1, $2, $3, $4, $5, $6) RETURNING idx'
     const passwordDigest = await argon2.hash(password)
-    const uid = await this.generateUid(client)
-    const result = await client.query(query, [username, passwordDigest, name, uid, shell, preferredLanguage])
+    const uid = await this.generateUid(tr)
+    const result = await tr.query(query, [username, passwordDigest, name, uid, shell, preferredLanguage])
     this.posixAccountsCache = null
     return result.rows[0].idx
   }
 
-  public async delete(client: PoolClient, userIdx: number): Promise<number> {
+  public async delete(tr: Transaction, userIdx: number): Promise<number> {
     const query = 'DELETE FROM users WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -54,56 +54,56 @@ export default class Users {
     return result.rows[0].idx
   }
 
-  public async getAll(client: PoolClient): Promise<Array<User>> {
+  public async getAll(tr: Transaction): Promise<Array<User>> {
     const query = 'SELECT idx, username, name, uid, shell FROM users'
-    const result = await client.query(query)
+    const result = await tr.query(query)
     const users: Array<User> = []
     result.rows.forEach(row => users.push(this.rowToUser(row)))
     return users
   }
 
-  public async getAllAsPosixAccounts(client: PoolClient): Promise<Array<ldap.SearchEntry<PosixAccount>>> {
+  public async getAllAsPosixAccounts(tr: Transaction): Promise<Array<ldap.SearchEntry<PosixAccount>>> {
     if (this.posixAccountsCache === null) {
-      this.posixAccountsCache = this.usersToPosixAccounts(await this.getAll(client))
+      this.posixAccountsCache = this.usersToPosixAccounts(await this.getAll(tr))
     }
     return this.posixAccountsCache
   }
 
-  public async getByUsername(client: PoolClient, username: string): Promise<User> {
+  public async getByUsername(tr: Transaction, username: string): Promise<User> {
     const query = 'SELECT idx, username, name, uid, shell FROM users WHERE username = $1'
-    const result = await client.query(query, [username])
+    const result = await tr.query(query, [username])
     if (result.rows.length !== 1) {
       throw new NoSuchEntryError()
     }
     return this.rowToUser(result.rows[0])
   }
 
-  public async getByUsernameAsPosixAccount(client: PoolClient, username: string):
+  public async getByUsernameAsPosixAccount(tr: Transaction, username: string):
       Promise<ldap.SearchEntry<PosixAccount>> {
-    return this.userToPosixAccount(await this.getByUsername(client, username))
+    return this.userToPosixAccount(await this.getByUsername(tr, username))
   }
 
-  public async getByUserIdx(client: PoolClient, userIdx: number): Promise<User> {
+  public async getByUserIdx(tr: Transaction, userIdx: number): Promise<User> {
     const query = 'SELECT idx, username, name, uid, shell FROM users WHERE idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     if (result.rows.length !== 1) {
       throw new NoSuchEntryError()
     }
     return this.rowToUser(result.rows[0])
   }
 
-  public async getUserIdxByEmailAddress(client: PoolClient, emailLocal: string, emailDomain: string): Promise<number> {
+  public async getUserIdxByEmailAddress(tr: Transaction, emailLocal: string, emailDomain: string): Promise<number> {
     const query = 'SELECT owner_idx FROM email_addresses WHERE LOWER(address_local) = LOWER($1) AND address_domain = $2'
-    const result = await client.query(query, [emailLocal, emailDomain])
+    const result = await tr.query(query, [emailLocal, emailDomain])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].owner_idx
   }
 
-  public async authenticate(client: PoolClient, username: string, password: string): Promise<number> {
+  public async authenticate(tr: Transaction, username: string, password: string): Promise<number> {
     const query = 'SELECT idx, password_digest, activated FROM users WHERE username = $1'
-    const result = await client.query(query, [username])
+    const result = await tr.query(query, [username])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -124,74 +124,74 @@ export default class Users {
       if (!hash.digest().equals(phcObject.hash)) {
         throw new AuthenticationError()
       }
-      await this.changePassword(client, idx, password)
+      await this.changePassword(tr, idx, password)
     } else if (!await argon2.verify(passwordDigest, password)) {
       throw new AuthenticationError()
     }
 
-    await this.model.users.updateLastLoginAt(client, idx)
+    await this.model.users.updateLastLoginAt(tr, idx)
     return idx
   }
 
-  public async updateLastLoginAt(client: PoolClient, userIdx: number): Promise<void> {
+  public async updateLastLoginAt(tr: Transaction, userIdx: number): Promise<void> {
     const query = 'UPDATE users SET last_login_at = NOW() WHERE idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
   }
 
-  public async activate(client: PoolClient, userIdx: number): Promise<void> {
+  public async activate(tr: Transaction, userIdx: number): Promise<void> {
     const query = 'UPDATE users SET activated = TRUE WHERE idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
   }
 
-  public async deactivate(client: PoolClient, userIdx: number): Promise<void> {
+  public async deactivate(tr: Transaction, userIdx: number): Promise<void> {
     const query = 'UPDATE users SET activated = FALSE WHERE idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
   }
 
-  public async generateUid(client: PoolClient): Promise<number> {
+  public async generateUid(tr: Transaction): Promise<number> {
     const minUid = this.model.config.posix.minUid
-    const getNewUidResult = await client.query('SELECT b.uid + 1 AS uid FROM users AS a RIGHT OUTER JOIN ' +
+    const getNewUidResult = await tr.query('SELECT b.uid + 1 AS uid FROM users AS a RIGHT OUTER JOIN ' +
       'users AS b ON a.uid = b.uid + 1 WHERE a.uid IS NULL AND b.uid + 1 >= $1 ORDER BY b.uid LIMIT 1', [minUid])
     return getNewUidResult.rows.length ? getNewUidResult.rows[0].uid : minUid
   }
 
-  public async generatePasswordChangeToken(client: PoolClient, userIdx: number): Promise<string> {
-    await this.resetResendCountIfExpired(client, userIdx)
+  public async generatePasswordChangeToken(tr: Transaction, userIdx: number): Promise<string> {
+    await this.resetResendCountIfExpired(tr, userIdx)
     const query = 'INSERT INTO password_change_tokens AS p(user_idx, token, expires) VALUES ($1, $2, $3) ' +
     'ON CONFLICT (user_idx) DO UPDATE SET token = $2, resend_count = p.resend_count + 1, expires = $3'
     const randomBytes = await this.asyncRandomBytes(32)
     const token = randomBytes.toString('hex')
     const expires = moment().add(1, 'day').toDate()
-    const result = await client.query(query, [userIdx, token, expires])
+    const result = await tr.query(query, [userIdx, token, expires])
     return token
   }
 
-  public async resetResendCountIfExpired(client: PoolClient, userIdx: number): Promise<void> {
+  public async resetResendCountIfExpired(tr: Transaction, userIdx: number): Promise<void> {
     const query = 'UPDATE password_change_tokens SET resend_count = 0 WHERE user_idx = $1 AND expires <= now()'
-    await client.query(query, [userIdx])
+    await tr.query(query, [userIdx])
   }
 
-  public async getResendCount(client: PoolClient, token: string): Promise<number> {
+  public async getResendCount(tr: Transaction, token: string): Promise<number> {
     const query = 'SELECT resend_count FROM password_change_tokens WHERE token = $1'
-    const result = await client.query(query, [token])
+    const result = await tr.query(query, [token])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].resend_count
   }
 
-  public async removeToken(client: PoolClient, token: string): Promise<number> {
+  public async removeToken(tr: Transaction, token: string): Promise<number> {
     const query = 'DELETE FROM password_change_tokens WHERE token = $1 RETURNING idx'
-    const result = await client.query(query, [token])
+    const result = await tr.query(query, [token])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
   }
 
-  public async ensureTokenNotExpired(client: PoolClient, token: string): Promise<void> {
+  public async ensureTokenNotExpired(tr: Transaction, token: string): Promise<void> {
     const query = 'SELECT expires FROM password_change_tokens WHERE token = $1'
-    const result = await client.query(query, [token])
+    const result = await tr.query(query, [token])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -203,19 +203,19 @@ export default class Users {
     }
   }
 
-  public async changePassword(client: PoolClient, userIdx: number, newPassword: string): Promise<number> {
+  public async changePassword(tr: Transaction, userIdx: number, newPassword: string): Promise<number> {
     const passwordDigest = await argon2.hash(newPassword)
     const query = 'UPDATE users SET password_digest = $1 WHERE idx = $2 RETURNING idx'
-    const result = await client.query(query, [passwordDigest, userIdx])
+    const result = await tr.query(query, [passwordDigest, userIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
   }
 
-  public async changeShell(client: PoolClient, userIdx: number, shell: string): Promise<number> {
+  public async changeShell(tr: Transaction, userIdx: number, shell: string): Promise<number> {
     const query = 'UPDATE users SET shell = $1 WHERE idx = $2 RETURNING idx'
-    const result = await client.query(query, [shell, userIdx])
+    const result = await tr.query(query, [shell, userIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
@@ -223,45 +223,45 @@ export default class Users {
     return result.rows[0].idx
   }
 
-  public async getShell(client: PoolClient, userIdx: number): Promise<string> {
+  public async getShell(tr: Transaction, userIdx: number): Promise<string> {
     const query = 'SELECT shell FROM users WHERE idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].shell
   }
 
-  public async addUserMembership(client: PoolClient, userIdx: number, groupIdx: number): Promise<number> {
+  public async addUserMembership(tr: Transaction, userIdx: number, groupIdx: number): Promise<number> {
     const query = 'INSERT INTO user_memberships(user_idx, group_idx) VALUES ($1, $2) RETURNING idx'
-    const result = await client.query(query, [userIdx, groupIdx])
+    const result = await tr.query(query, [userIdx, groupIdx])
     return result.rows[0].idx
   }
 
-  public async deleteUserMembership(client: PoolClient, userMembershipIdx: number): Promise<number> {
+  public async deleteUserMembership(tr: Transaction, userMembershipIdx: number): Promise<number> {
     const query = 'DELETE FROM user_memberships WHERE idx = $1 RETURNING idx'
-    const result = await client.query(query, [userMembershipIdx])
+    const result = await tr.query(query, [userMembershipIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].idx
   }
 
-  public async getAllUserMemberships(client: PoolClient, userIdx: number): Promise<Array<UserMembership>> {
+  public async getAllUserMemberships(tr: Transaction, userIdx: number): Promise<Array<UserMembership>> {
     const query = 'SELECT user_idx, group_idx FROM user_memberships WHERE user_idx = $1'
-    const result = await client.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows.map(row => this.rowToUserMembership(row))
   }
 
-  public async getUserReachableGroups(client: PoolClient, userIdx: number): Promise<Set<number>> {
-    const userMemberships = await this.getAllUserMemberships(client, userIdx)
+  public async getUserReachableGroups(tr: Transaction, userIdx: number): Promise<Set<number>> {
+    const userMemberships = await this.getAllUserMemberships(tr, userIdx)
     const groupSet = new Set<number>()
 
     for (const userMembership of userMemberships) {
-      const reachableGroups = await this.model.groups.getGroupReachableArray(client, userMembership.groupIdx)
+      const reachableGroups = await this.model.groups.getGroupReachableArray(tr, userMembership.groupIdx)
       reachableGroups.forEach(gi => {
         groupSet.add(gi)
       })
@@ -270,18 +270,18 @@ export default class Users {
     return groupSet
   }
 
-  public async getUserIdxByPasswordToken(client: PoolClient, token: string): Promise<number> {
+  public async getUserIdxByPasswordToken(tr: Transaction, token: string): Promise<number> {
     const query = 'SELECT user_idx FROM password_change_tokens WHERE token = $1'
-    const result = await client.query(query, [token])
+    const result = await tr.query(query, [token])
     if (result.rows.length === 0) {
       throw new NoSuchEntryError()
     }
     return result.rows[0].user_idx
   }
 
-  public async addStudentNumber(client: PoolClient, userIdx: number, studentNumber: string): Promise<number> {
+  public async addStudentNumber(tr: Transaction, userIdx: number, studentNumber: string): Promise<number> {
     const query = 'INSERT INTO student_numbers(student_number, owner_idx) VALUES ($1, $2) RETURNING idx'
-    const result = await client.query(query, [studentNumber, userIdx])
+    const result = await tr.query(query, [studentNumber, userIdx])
     return result.rows[0].idx
   }
 

--- a/core/test/api/email.test.ts
+++ b/core/test/api/email.test.ts
@@ -24,10 +24,10 @@ test('check token api', async t => {
   const local = uuid()
   const domain = uuid()
 
-  await model.pgDo(async c => {
-    const emailAddressIdx = await model.emailAddresses.create(c, local, domain)
-    await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
-    const result = await c.query('SELECT token FROM email_verification_tokens WHERE email_idx = $1', [emailAddressIdx])
+  await model.pgDo(async tr => {
+    const emailAddressIdx = await model.emailAddresses.create(tr, local, domain)
+    await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
+    const result = await tr.query('SELECT token FROM email_verification_tokens WHERE email_idx = $1', [emailAddressIdx])
 
     token = result.rows[0].token
   })

--- a/core/test/api/login.test.ts
+++ b/core/test/api/login.test.ts
@@ -14,7 +14,7 @@ test('test login with credential', async t => {
     password = uuid()
     userIdx = await model.users.create(
       tr, username, password, uuid(), '/bin/bash', 'en')
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 
@@ -50,7 +50,7 @@ test('test checkLogin', async t => {
     password = uuid()
     userIdx = await model.users.create(
       tr, username, password, uuid(), '/bin/bash', 'en')
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 
@@ -86,7 +86,7 @@ test('test legacy login', async t => {
     password = uuid()
     userIdx = await model.users.create(
       tr, username, password, uuid(), '/bin/bash', 'en')
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 

--- a/core/test/api/login.test.ts
+++ b/core/test/api/login.test.ts
@@ -9,11 +9,11 @@ test('test login with credential', async t => {
   let password: string = ''
   let userIdx: number = -1
 
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     username = uuid()
     password = uuid()
     userIdx = await model.users.create(
-      c, username, password, uuid(), '/bin/bash', 'en')
+      tr, username, password, uuid(), '/bin/bash', 'en')
   })
 
   const agent = request.agent(app)
@@ -32,9 +32,9 @@ test('test login with credential', async t => {
   })
   t.is(response.status, 200)
 
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const query = 'SELECT last_login_at FROM users WHERE idx = $1'
-    const result = await c.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     const lastLogin = moment(result.rows[0].last_login_at)
     t.true(lastLogin.isBetween(moment().subtract(10, 'seconds'), moment().add(10, 'seconds')))
   })
@@ -45,11 +45,11 @@ test('test checkLogin', async t => {
   let password: string = ''
   let userIdx: number = -1
 
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     username = uuid()
     password = uuid()
     userIdx = await model.users.create(
-      c, username, password, uuid(), '/bin/bash', 'en')
+      tr, username, password, uuid(), '/bin/bash', 'en')
   })
 
   const agent = request.agent(app)
@@ -81,11 +81,11 @@ test('test legacy login', async t => {
   let password: string = ''
   let userIdx: number = -1
 
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     username = uuid()
     password = uuid()
     userIdx = await model.users.create(
-      c, username, password, uuid(), '/bin/bash', 'en')
+      tr, username, password, uuid(), '/bin/bash', 'en')
   })
 
   const agent = request.agent(app)

--- a/core/test/api/shells.test.ts
+++ b/core/test/api/shells.test.ts
@@ -6,9 +6,9 @@ import { app, model } from '../setup'
 test('test getShells', async t => {
   let result
   const newShell = uuid()
-  await model.pgDo(async c => {
-    await model.shells.addShell(c, newShell)
-    result = await model.shells.getShells(c)
+  await model.pgDo(async tr => {
+    await model.shells.addShell(tr, newShell)
+    result = await model.shells.getShells(tr)
   })
 
   const agent = request.agent(app)

--- a/core/test/api/users.test.ts
+++ b/core/test/api/users.test.ts
@@ -27,9 +27,9 @@ test('create user step by step', async t => {
   t.is(response.status, 200)
 
   let token: string = ''
-  await model.pgDo(async c => {
-    const idx = await model.emailAddresses.getIdxByAddress(c, emailLocal, emailDomain)
-    const result = await c.query('SELECT token FROM email_verification_tokens WHERE email_idx = $1', [idx])
+  await model.pgDo(async tr => {
+    const idx = await model.emailAddresses.getIdxByAddress(tr, emailLocal, emailDomain)
+    const result = await tr.query('SELECT token FROM email_verification_tokens WHERE email_idx = $1', [idx])
     token = result.rows[0].token
   })
 
@@ -94,8 +94,8 @@ test('create user step by step', async t => {
   })
   t.is(response.status, 201)
 
-  await model.pgDo(async c => {
-    await c.query('TRUNCATE student_numbers')
+  await model.pgDo(async tr => {
+    await tr.query('TRUNCATE student_numbers')
   })
 })
 
@@ -104,13 +104,13 @@ test('get user email addresses', async t => {
   const password = uuid()
   let userIdx
 
-  await model.pgDo(async c => {
-    const emailIdx1 = await model.emailAddresses.create(c, uuid(), uuid())
-    const emailIdx2 = await model.emailAddresses.create(c, uuid(), uuid())
+  await model.pgDo(async tr => {
+    const emailIdx1 = await model.emailAddresses.create(tr, uuid(), uuid())
+    const emailIdx2 = await model.emailAddresses.create(tr, uuid(), uuid())
 
-    userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
-    await model.emailAddresses.validate(c, userIdx, emailIdx1)
-    await model.emailAddresses.validate(c, userIdx, emailIdx2)
+    userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
+    await model.emailAddresses.validate(tr, userIdx, emailIdx1)
+    await model.emailAddresses.validate(tr, userIdx, emailIdx2)
   })
 
   const agent = request.agent(app)
@@ -138,10 +138,10 @@ test('change password', async t => {
   const emailDomain = uuid()
   let userIdx = -1
 
-  await model.pgDo(async c => {
-    const emailIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
-    await model.emailAddresses.validate(c, userIdx, emailIdx)
+  await model.pgDo(async tr => {
+    const emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
+    await model.emailAddresses.validate(tr, userIdx, emailIdx)
   })
 
   const agent = request.agent(app)
@@ -155,8 +155,8 @@ test('change password', async t => {
   t.is(response.status, 200)
 
   let token
-  await model.pgDo(async c => {
-    const result = await c.query('SELECT token FROM password_change_tokens WHERE user_idx = $1', [userIdx])
+  await model.pgDo(async tr => {
+    const result = await tr.query('SELECT token FROM password_change_tokens WHERE user_idx = $1', [userIdx])
     t.is(result.rows.length, 1)
     token = result.rows[0].token
   })
@@ -174,8 +174,8 @@ test('change password', async t => {
   })
   t.is(response.status, 200)
 
-  await model.pgDo(async c => {
-    await model.users.authenticate(c, username, newPassword)
+  await model.pgDo(async tr => {
+    await model.users.authenticate(tr, username, newPassword)
   })
 
   t.pass()
@@ -187,11 +187,11 @@ test('change shell', async t => {
   const newShell = uuid()
   let userIdx = -1
 
-  await model.pgDo(async c => {
-    const emailIdx = await model.emailAddresses.create(c, uuid(), uuid())
-    userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
-    await model.emailAddresses.validate(c, userIdx, emailIdx)
-    await model.shells.addShell(c, newShell)
+  await model.pgDo(async tr => {
+    const emailIdx = await model.emailAddresses.create(tr, uuid(), uuid())
+    userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
+    await model.emailAddresses.validate(tr, userIdx, emailIdx)
+    await model.shells.addShell(tr, newShell)
   })
 
   const agent = request.agent(app)
@@ -222,8 +222,8 @@ test('verification email resend limit', async t => {
   const resendLimit = config.email.resendLimit
   let emailIdx = -1
 
-  await model.pgDo(async c => {
-    emailIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
+  await model.pgDo(async tr => {
+    emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
   })
 
   const agent = request.agent(app)
@@ -250,10 +250,10 @@ test('password change email resend limit', async t => {
   const resendLimit = config.email.resendLimit
   let emailIdx = -1
 
-  await model.pgDo(async c => {
-    emailIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
-    await model.emailAddresses.validate(c, userIdx, emailIdx)
+  await model.pgDo(async tr => {
+    emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    await model.emailAddresses.validate(tr, userIdx, emailIdx)
   })
 
   const agent = request.agent(app)
@@ -282,8 +282,8 @@ test('password change email resend limit', async t => {
     let count = 0
 
     for (let i = 0; i < NUMBER_OF_USERS_TO_CREATE; i++) {
-      promises[i] = model.pgDo(async c => {
-        indices[i] = await model.users.create(c, i.toString(), 'password' + i, i.toString(), '/bin/bash', 'en')
+      promises[i] = model.pgDo(async tr => {
+        indices[i] = await model.users.create(tr, i.toString(), 'password' + i, i.toString(), '/bin/bash', 'en')
       }).then(async () => {
         count++
         if (count === NUMBER_OF_USERS_TO_CREATE) {
@@ -300,8 +300,8 @@ test('password change email resend limit', async t => {
 
   async function verifyResult<T>(t: GenericTestContext<T>, indcies: Array<number>) {
     for (let i = 0; i < NUMBER_OF_USERS_TO_CREATE; i++) {
-      await model.pgDo(async c => {
-        const user = await model.users.getByUserIdx(c, indcies[i])
+      await model.pgDo(async tr => {
+        const user = await model.users.getByUserIdx(tr, indcies[i])
         t.is(user.name, i.toString())
       })
     }
@@ -309,8 +309,8 @@ test('password change email resend limit', async t => {
 
   async function cleanUpUsers<T>(t: GenericTestContext<T>, indices: Array<number>) {
     for (let i = 0; i < NUMBER_OF_USERS_TO_CREATE; i++) {
-      await model.pgDo(async c => {
-        await model.users.delete(c, indices[i])
+      await model.pgDo(async tr => {
+        await model.users.delete(tr, indices[i])
       })
     }
   }

--- a/core/test/api/users.test.ts
+++ b/core/test/api/users.test.ts
@@ -111,7 +111,7 @@ test('get user email addresses', async t => {
     userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
     await model.emailAddresses.validate(tr, userIdx, emailIdx1)
     await model.emailAddresses.validate(tr, userIdx, emailIdx2)
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 
@@ -142,7 +142,7 @@ test('change password', async t => {
     const emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
     userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
     await model.emailAddresses.validate(tr, userIdx, emailIdx)
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 
@@ -192,7 +192,7 @@ test('change shell', async t => {
     userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
     await model.emailAddresses.validate(tr, userIdx, emailIdx)
     await model.shells.addShell(tr, newShell)
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
 
@@ -254,7 +254,7 @@ test('password change email resend limit', async t => {
     emailIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
     const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
     await model.emailAddresses.validate(tr, userIdx, emailIdx)
-  })
+  }, ['users'])
 
   const agent = request.agent(app)
   let response
@@ -284,7 +284,7 @@ test('password change email resend limit', async t => {
     for (let i = 0; i < NUMBER_OF_USERS_TO_CREATE; i++) {
       promises[i] = model.pgDo(async tr => {
         indices[i] = await model.users.create(tr, i.toString(), 'password' + i, i.toString(), '/bin/bash', 'en')
-      }).then(async () => {
+      }, ['users']).then(async () => {
         count++
         if (count === NUMBER_OF_USERS_TO_CREATE) {
           await verifyResult(t, indices)

--- a/core/test/model/email_addresses.test.ts
+++ b/core/test/model/email_addresses.test.ts
@@ -18,7 +18,7 @@ test('create extra email', async t => {
     const query = 'SELECT * FROM email_addresses WHERE idx = $1'
     const result = await tr.query(query, [emailAddressIdx])
     t.is(result.rows[0].owner_idx, userIdx)
-  })
+  }, ['users'])
 })
 
 test('generate verification token', async t => {
@@ -30,7 +30,7 @@ test('generate verification token', async t => {
     const query = 'SELECT * FROM email_verification_tokens WHERE email_idx = $1'
     const result = await tr.query(query, [emailAddressIdx])
     t.is(result.rows.length, 1)
-  })
+  }, ['users'])
 })
 
 test('get email address by token', async t => {
@@ -49,7 +49,7 @@ test('get email address by token', async t => {
 
     t.is(result.local, emailLocal)
     t.is(result.domain, emailDomain)
-  })
+  }, ['users'])
 })
 
 test('identical address should not create new row', async t => {
@@ -126,7 +126,7 @@ test('get user emails', async t => {
     t.is(result.length, 2)
     t.is(result[0].local, emailLocal)
     t.is(result[0].domain, emailDomain)
-  })
+  }, ['users'])
 })
 
 test('reset resend count of expired verification token', async t => {

--- a/core/test/model/email_addresses.test.ts
+++ b/core/test/model/email_addresses.test.ts
@@ -9,42 +9,43 @@ import { createEmailAddress, createUser } from '../test_utils'
 import { model } from '../setup'
 
 test('create extra email', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
-    const emailAddressIdx = await createEmailAddress(c, model)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
+    const emailAddressIdx = await createEmailAddress(tr, model)
 
-    await model.emailAddresses.validate(c, userIdx, emailAddressIdx)
+    await model.emailAddresses.validate(tr, userIdx, emailAddressIdx)
 
     const query = 'SELECT * FROM email_addresses WHERE idx = $1'
-    const result = await c.query(query, [emailAddressIdx])
+    const result = await tr.query(query, [emailAddressIdx])
     t.is(result.rows[0].owner_idx, userIdx)
   })
 })
 
 test('generate verification token', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
-    const emailAddressIdx = await createEmailAddress(c, model)
-    await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
+    const emailAddressIdx = await createEmailAddress(tr, model)
+    await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
 
     const query = 'SELECT * FROM email_verification_tokens WHERE email_idx = $1'
-    const result = await c.query(query, [emailAddressIdx])
+    const result = await tr.query(query, [emailAddressIdx])
     t.is(result.rows.length, 1)
   })
 })
 
 test('get email address by token', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
 
-    const tokenResult = await c.query('SELECT * FROM email_verification_tokens WHERE email_idx = $1', [emailAddressIdx])
+    const tokenResult = await tr.query('SELECT * FROM email_verification_tokens WHERE email_idx = $1',
+      [emailAddressIdx])
     const token: string = tokenResult.rows[0].token
 
-    const result = await model.emailAddresses.getEmailAddressByToken(c, token)
+    const result = await model.emailAddresses.getEmailAddressByToken(tr, token)
 
     t.is(result.local, emailLocal)
     t.is(result.domain, emailDomain)
@@ -52,30 +53,30 @@ test('get email address by token', async t => {
 })
 
 test('identical address should not create new row', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const newEmailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const newEmailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
 
     t.is(emailAddressIdx, newEmailAddressIdx)
 
-    const upperCasedIdx = await model.emailAddresses.create(c, emailLocal.toUpperCase(), emailDomain.toUpperCase())
+    const upperCasedIdx = await model.emailAddresses.create(tr, emailLocal.toUpperCase(), emailDomain.toUpperCase())
 
     t.is(emailAddressIdx, upperCasedIdx)
   })
 })
 
 test('verification token request with identical email idx', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const oldToken = await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
-    const newToken = await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const oldToken = await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
+    const newToken = await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
 
     const query = 'SELECT token FROM email_verification_tokens WHERE email_idx = $1'
-    const result = await c.query(query, [emailAddressIdx])
+    const result = await tr.query(query, [emailAddressIdx])
     const token = result.rows[0].token
     t.is(newToken, token)
     t.not(oldToken, token)
@@ -83,24 +84,24 @@ test('verification token request with identical email idx', async t => {
 })
 
 test('token expiration', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const token = await model.emailAddresses.generateVerificationToken(c, emailAddressIdx)
-    const expiryResult = await c.query('SELECT expires FROM email_verification_tokens WHERE token = $1', [token])
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const token = await model.emailAddresses.generateVerificationToken(tr, emailAddressIdx)
+    const expiryResult = await tr.query('SELECT expires FROM email_verification_tokens WHERE token = $1', [token])
     const originalExpires = expiryResult.rows[0].expires
 
     const query = 'UPDATE email_verification_tokens SET expires = $1 WHERE token = $2'
     let newExpiry = moment(originalExpires).subtract(12, 'hours').toDate()
-    await c.query(query, [newExpiry, token])
-    await model.emailAddresses.ensureTokenNotExpired(c, token)
+    await tr.query(query, [newExpiry, token])
+    await model.emailAddresses.ensureTokenNotExpired(tr, token)
 
     newExpiry = moment(originalExpires).subtract(1, 'day').toDate()
-    await c.query(query, [newExpiry, token])
+    await tr.query(query, [newExpiry, token])
 
     try {
-      await model.emailAddresses.ensureTokenNotExpired(c, token)
+      await model.emailAddresses.ensureTokenNotExpired(tr, token)
     } catch (e) {
       t.pass()
       return
@@ -111,17 +112,17 @@ test('token expiration', async t => {
 })
 
 test('get user emails', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const emailAddressIdx2 = await createEmailAddress(c, model)
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const emailAddressIdx2 = await createEmailAddress(tr, model)
 
-    await model.emailAddresses.validate(c, userIdx, emailAddressIdx)
-    await model.emailAddresses.validate(c, userIdx, emailAddressIdx2)
+    await model.emailAddresses.validate(tr, userIdx, emailAddressIdx)
+    await model.emailAddresses.validate(tr, userIdx, emailAddressIdx2)
 
-    const result = await model.emailAddresses.getEmailsByOwnerIdx(c, userIdx)
+    const result = await model.emailAddresses.getEmailsByOwnerIdx(tr, userIdx)
     t.is(result.length, 2)
     t.is(result[0].local, emailLocal)
     t.is(result[0].domain, emailDomain)
@@ -129,17 +130,17 @@ test('get user emails', async t => {
 })
 
 test('reset resend count of expired verification token', async t => {
-  await model.pgDo(async c => {
-    const emailIdx = await model.emailAddresses.create(c, uuid(), uuid())
-    let token = await model.emailAddresses.generateVerificationToken(c, emailIdx)
-    const expiryResult = await c.query('SELECT expires FROM email_verification_tokens WHERE token = $1', [token])
+  await model.pgDo(async tr => {
+    const emailIdx = await model.emailAddresses.create(tr, uuid(), uuid())
+    let token = await model.emailAddresses.generateVerificationToken(tr, emailIdx)
+    const expiryResult = await tr.query('SELECT expires FROM email_verification_tokens WHERE token = $1', [token])
     const originalExpires = expiryResult.rows[0].expires
     const query = 'UPDATE email_verification_tokens SET expires = $1, resend_count = 100 WHERE token = $2'
     const newExpiry = moment(originalExpires).subtract(2, 'day').toDate()
-    await c.query(query, [newExpiry, token])
-    token = await model.emailAddresses.generateVerificationToken(c, emailIdx)
+    await tr.query(query, [newExpiry, token])
+    token = await model.emailAddresses.generateVerificationToken(tr, emailIdx)
 
-    const resendCount = await model.emailAddresses.getResendCount(c, token)
+    const resendCount = await model.emailAddresses.getResendCount(tr, token)
     t.is(resendCount, 1)
   })
 })

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -95,5 +95,5 @@ test('get reachable group object', async t => {
 
     result = await model.groups.getGroupReachableArray(tr, g[4])
     t.deepEqual(result, [g[4]])
-  }, ['group_reachable_cache', 'users'])
+  }, ['group_reachable_cache'])
 })

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -37,7 +37,7 @@ test('create and delete group', async t => {
     }
 
     t.fail()
-  })
+  }, ['group_reachable_cache'])
 })
 
 test('set owner user', async t => {
@@ -50,7 +50,7 @@ test('set owner user', async t => {
 
     await model.groups.setOwnerUser(tr, groupIdx, null)
     t.is((await model.groups.getByIdx(tr, groupIdx)).ownerUserIdx, null)
-  }, ['users'])
+  }, ['users', 'group_reachable_cache'])
 })
 
 test('set owner group', async t => {
@@ -63,7 +63,7 @@ test('set owner group', async t => {
 
     await model.groups.setOwnerGroup(tr, groupIdx, null)
     t.is((await model.groups.getByIdx(tr, groupIdx)).ownerGroupIdx, null)
-  })
+  }, ['group_reachable_cache'])
 })
 
 test('get reachable group object', async t => {
@@ -95,5 +95,5 @@ test('get reachable group object', async t => {
 
     result = await model.groups.getGroupReachableArray(tr, g[4])
     t.deepEqual(result, [g[4]])
-  })
+  }, ['group_reachable_cache'])
 })

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -50,7 +50,7 @@ test('set owner user', async t => {
 
     await model.groups.setOwnerUser(tr, groupIdx, null)
     t.is((await model.groups.getByIdx(tr, groupIdx)).ownerUserIdx, null)
-  })
+  }, ['users'])
 })
 
 test('set owner group', async t => {

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -17,19 +17,19 @@ const description: Translation = {
 }
 
 test('create and delete group', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
 
-    const idx = await model.groups.create(c, name, description)
-    const row = await model.groups.getByIdx(c, idx)
+    const idx = await model.groups.create(tr, name, description)
+    const row = await model.groups.getByIdx(tr, idx)
 
     t.deepEqual(row.name, name)
     t.deepEqual(row.description, description)
 
-    const deleteIdx = await model.groups.delete(c, idx)
+    const deleteIdx = await model.groups.delete(tr, idx)
     t.is(idx, deleteIdx)
 
     try {
-      await model.groups.getByIdx(c, idx)
+      await model.groups.getByIdx(tr, idx)
     } catch (e) {
       if (e instanceof NoSuchEntryError) {
         return
@@ -41,59 +41,59 @@ test('create and delete group', async t => {
 })
 
 test('set owner user', async t => {
-  await model.pgDo(async c => {
-    const groupIdx = await createGroup(c, model)
-    const userIdx = await createUser(c, model)
+  await model.pgDo(async tr => {
+    const groupIdx = await createGroup(tr, model)
+    const userIdx = await createUser(tr, model)
 
-    await model.groups.setOwnerUser(c, groupIdx, userIdx)
-    t.is((await model.groups.getByIdx(c, groupIdx)).ownerUserIdx, userIdx)
+    await model.groups.setOwnerUser(tr, groupIdx, userIdx)
+    t.is((await model.groups.getByIdx(tr, groupIdx)).ownerUserIdx, userIdx)
 
-    await model.groups.setOwnerUser(c, groupIdx, null)
-    t.is((await model.groups.getByIdx(c, groupIdx)).ownerUserIdx, null)
+    await model.groups.setOwnerUser(tr, groupIdx, null)
+    t.is((await model.groups.getByIdx(tr, groupIdx)).ownerUserIdx, null)
   })
 })
 
 test('set owner group', async t => {
-  await model.pgDo(async c => {
-    const groupIdx = await createGroup(c, model)
-    const ownerGroupIdx = await createGroup(c, model)
+  await model.pgDo(async tr => {
+    const groupIdx = await createGroup(tr, model)
+    const ownerGroupIdx = await createGroup(tr, model)
 
-    await model.groups.setOwnerGroup(c, groupIdx, ownerGroupIdx)
-    t.is((await model.groups.getByIdx(c, groupIdx)).ownerGroupIdx, ownerGroupIdx)
+    await model.groups.setOwnerGroup(tr, groupIdx, ownerGroupIdx)
+    t.is((await model.groups.getByIdx(tr, groupIdx)).ownerGroupIdx, ownerGroupIdx)
 
-    await model.groups.setOwnerGroup(c, groupIdx, null)
-    t.is((await model.groups.getByIdx(c, groupIdx)).ownerGroupIdx, null)
+    await model.groups.setOwnerGroup(tr, groupIdx, null)
+    t.is((await model.groups.getByIdx(tr, groupIdx)).ownerGroupIdx, null)
   })
 })
 
 test('get reachable group object', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const g: Array<number> = []
     const range: Array<number> = [...Array(5).keys()]
     for (const _ of range) {
-      g.push(await createGroup(c, model))
+      g.push(await createGroup(tr, model))
     }
 
-    await createGroupRelation(c, model, g[0], g[1])
-    await createGroupRelation(c, model, g[0], g[2])
-    await createGroupRelation(c, model, g[1], g[3])
-    await createGroupRelation(c, model, g[1], g[4])
+    await createGroupRelation(tr, model, g[0], g[1])
+    await createGroupRelation(tr, model, g[0], g[2])
+    await createGroupRelation(tr, model, g[1], g[3])
+    await createGroupRelation(tr, model, g[1], g[4])
 
     let result: Array<number> = []
 
-    result = await model.groups.getGroupReachableArray(c, g[0])
+    result = await model.groups.getGroupReachableArray(tr, g[0])
     t.deepEqual(result.sort(), [g[0], g[1], g[2], g[3], g[4]].sort())
 
-    result = await model.groups.getGroupReachableArray(c, g[1])
+    result = await model.groups.getGroupReachableArray(tr, g[1])
     t.deepEqual(result.sort(), [g[1], g[3], g[4]].sort())
 
-    result = await model.groups.getGroupReachableArray(c, g[2])
+    result = await model.groups.getGroupReachableArray(tr, g[2])
     t.deepEqual(result, [g[2]])
 
-    result = await model.groups.getGroupReachableArray(c, g[3])
+    result = await model.groups.getGroupReachableArray(tr, g[3])
     t.deepEqual(result, [g[3]])
 
-    result = await model.groups.getGroupReachableArray(c, g[4])
+    result = await model.groups.getGroupReachableArray(tr, g[4])
     t.deepEqual(result, [g[4]])
   })
 })

--- a/core/test/model/groups.test.ts
+++ b/core/test/model/groups.test.ts
@@ -95,5 +95,5 @@ test('get reachable group object', async t => {
 
     result = await model.groups.getGroupReachableArray(tr, g[4])
     t.deepEqual(result, [g[4]])
-  }, ['group_reachable_cache'])
+  }, ['group_reachable_cache', 'users'])
 })

--- a/core/test/model/permissions.test.ts
+++ b/core/test/model/permissions.test.ts
@@ -18,11 +18,11 @@ const description: Translation = {
 }
 
 test('create and delete permissions', async t => {
-  await model.pgDo(async c => {
-    const permissionIdx = await model.permissions.create(c, name, description)
+  await model.pgDo(async tr => {
+    const permissionIdx = await model.permissions.create(tr, name, description)
 
     const query = 'SELECT * FROM permissions WHERE idx = $1'
-    const result = await c.query(query, [permissionIdx])
+    const result = await tr.query(query, [permissionIdx])
 
     t.truthy(result.rows[0])
     t.deepEqual(result.rows[0].name_ko, name.ko)
@@ -30,63 +30,63 @@ test('create and delete permissions', async t => {
     t.deepEqual(result.rows[0].description_ko, description.ko)
     t.deepEqual(result.rows[0].description_en, description.en)
 
-    const deletedPermissionIdx = await model.permissions.delete(c, permissionIdx)
-    const emptyResult = await c.query(query, [permissionIdx])
+    const deletedPermissionIdx = await model.permissions.delete(tr, permissionIdx)
+    const emptyResult = await tr.query(query, [permissionIdx])
 
     t.is(emptyResult.rows.length, 0)
   })
 })
 
 test('create and delete permission requirements', async t => {
-  await model.pgDo(async c => {
-    const groupIdx = await createGroup(c, model)
-    const permissionIdx = await createPermission(c, model)
-    const idx = await model.permissions.addPermissionRequirement(c, groupIdx, permissionIdx)
+  await model.pgDo(async tr => {
+    const groupIdx = await createGroup(tr, model)
+    const permissionIdx = await createPermission(tr, model)
+    const idx = await model.permissions.addPermissionRequirement(tr, groupIdx, permissionIdx)
 
     const query = 'SELECT * FROM permission_requirements WHERE idx = $1'
-    const result = await c.query(query, [idx])
+    const result = await tr.query(query, [idx])
 
     t.truthy(result.rows[0])
     t.is(result.rows[0].group_idx, groupIdx)
 
-    const deletedIdx = await model.permissions.deletePermissionRequirement(c, idx)
-    const emptyResult = await c.query(query, [idx])
+    const deletedIdx = await model.permissions.deletePermissionRequirement(tr, idx)
+    const emptyResult = await tr.query(query, [idx])
 
     t.is(emptyResult.rows.length, 0)
   })
 })
 
 test('check user permission', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const g: Array<number> = []
     const range: Array<number> = [...Array(5).keys()]
     for (const _ of range) {
-      g.push(await createGroup(c, model))
+      g.push(await createGroup(tr, model))
     }
 
-    await createGroupRelation(c, model, g[0], g[1])
-    await createGroupRelation(c, model, g[0], g[2])
-    await createGroupRelation(c, model, g[1], g[3])
-    await createGroupRelation(c, model, g[1], g[4])
+    await createGroupRelation(tr, model, g[0], g[1])
+    await createGroupRelation(tr, model, g[0], g[2])
+    await createGroupRelation(tr, model, g[1], g[3])
+    await createGroupRelation(tr, model, g[1], g[4])
 
-    const permissionIdx = await createPermission(c, model)
-    await model.permissions.addPermissionRequirement(c, g[2], permissionIdx)
-    await model.permissions.addPermissionRequirement(c, g[4], permissionIdx)
+    const permissionIdx = await createPermission(tr, model)
+    await model.permissions.addPermissionRequirement(tr, g[2], permissionIdx)
+    await model.permissions.addPermissionRequirement(tr, g[4], permissionIdx)
 
-    const userIdx1 = await createUser(c, model)
-    await model.users.addUserMembership(c, userIdx1, g[0])
+    const userIdx1 = await createUser(tr, model)
+    await model.users.addUserMembership(tr, userIdx1, g[0])
 
-    t.true(await model.permissions.checkUserHavePermission(c, userIdx1, permissionIdx))
+    t.true(await model.permissions.checkUserHavePermission(tr, userIdx1, permissionIdx))
 
-    const userIdx2 = await createUser(c, model)
-    await model.users.addUserMembership(c, userIdx2, g[1])
+    const userIdx2 = await createUser(tr, model)
+    await model.users.addUserMembership(tr, userIdx2, g[1])
 
-    t.false(await model.permissions.checkUserHavePermission(c, userIdx2, permissionIdx))
+    t.false(await model.permissions.checkUserHavePermission(tr, userIdx2, permissionIdx))
 
-    const userIdx3 = await createUser(c, model)
-    await model.users.addUserMembership(c, userIdx3, g[1])
-    await model.users.addUserMembership(c, userIdx3, g[2])
+    const userIdx3 = await createUser(tr, model)
+    await model.users.addUserMembership(tr, userIdx3, g[1])
+    await model.users.addUserMembership(tr, userIdx3, g[2])
 
-    t.true(await model.permissions.checkUserHavePermission(c, userIdx3, permissionIdx))
+    t.true(await model.permissions.checkUserHavePermission(tr, userIdx3, permissionIdx))
   })
 })

--- a/core/test/model/permissions.test.ts
+++ b/core/test/model/permissions.test.ts
@@ -88,5 +88,5 @@ test('check user permission', async t => {
     await model.users.addUserMembership(tr, userIdx3, g[2])
 
     t.true(await model.permissions.checkUserHavePermission(tr, userIdx3, permissionIdx))
-  })
+  }, ['users'])
 })

--- a/core/test/model/permissions.test.ts
+++ b/core/test/model/permissions.test.ts
@@ -53,7 +53,7 @@ test('create and delete permission requirements', async t => {
     const emptyResult = await tr.query(query, [idx])
 
     t.is(emptyResult.rows.length, 0)
-  })
+  }, ['group_reachable_cache'])
 })
 
 test('check user permission', async t => {
@@ -88,5 +88,5 @@ test('check user permission', async t => {
     await model.users.addUserMembership(tr, userIdx3, g[2])
 
     t.true(await model.permissions.checkUserHavePermission(tr, userIdx3, permissionIdx))
-  }, ['users'])
+  }, ['users', 'group_reachable_cache'])
 })

--- a/core/test/model/shells.test.ts
+++ b/core/test/model/shells.test.ts
@@ -6,13 +6,13 @@ import { model } from '../setup'
 
 test('get, add, and remove shells', async t => {
   const newShell = uuid()
-  await model.pgDo(async c => {
-    await model.shells.addShell(c, newShell)
-    const result = await model.shells.getShells(c)
+  await model.pgDo(async tr => {
+    await model.shells.addShell(tr, newShell)
+    const result = await model.shells.getShells(tr)
     t.true(result.includes(newShell))
 
-    await model.shells.removeShell(c, newShell)
-    const result2 = await model.shells.getShells(c)
+    await model.shells.removeShell(tr, newShell)
+    const result2 = await model.shells.getShells(tr)
     t.false(result2.includes(newShell))
   })
 })

--- a/core/test/model/shells.test.ts
+++ b/core/test/model/shells.test.ts
@@ -1,7 +1,5 @@
 import test from 'ava'
 import * as uuid from 'uuid/v4'
-
-import { createGroup, createUser, createGroupRelation } from '../test_utils'
 import { model } from '../setup'
 
 test('get, add, and remove shells', async t => {

--- a/core/test/model/users.test.ts
+++ b/core/test/model/users.test.ts
@@ -9,23 +9,23 @@ import { createUser, createGroup } from '../test_utils'
 import { model } from '../setup'
 
 test('create and delete user', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
 
-    const user1 = await model.users.getByUserIdx(c, userIdx)
+    const user1 = await model.users.getByUserIdx(tr, userIdx)
     if (user1.username === null) {
       t.fail()
       return
     }
 
-    const user2 = await model.users.getByUsername(c, user1.username)
+    const user2 = await model.users.getByUsername(tr, user1.username)
     t.is(user2.name, user1.name)
 
-    const deletedUserIdx = await model.users.delete(c, userIdx)
+    const deletedUserIdx = await model.users.delete(tr, userIdx)
     t.is(deletedUserIdx, userIdx)
 
     try {
-      await model.users.getByUserIdx(c, userIdx)
+      await model.users.getByUserIdx(tr, userIdx)
     } catch (e) {
       if (e instanceof NoSuchEntryError) {
         return
@@ -37,16 +37,16 @@ test('create and delete user', async t => {
 })
 
 test('authenticate user', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const username = uuid()
     const password = uuid()
-    const userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
-    await model.users.activate(c, userIdx)
+    const userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
+    await model.users.activate(tr, userIdx)
 
-    t.is(await model.users.authenticate(c, username, password), userIdx)
+    t.is(await model.users.authenticate(tr, username, password), userIdx)
 
     try {
-      await model.users.authenticate(c, username, password + 'doge')
+      await model.users.authenticate(tr, username, password + 'doge')
     } catch (e) {
       if (e instanceof AuthenticationError) {
         return
@@ -58,14 +58,14 @@ test('authenticate user', async t => {
 })
 
 test('reject not activated user', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const username = uuid()
     const password = uuid()
-    const userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
-    await model.users.deactivate(c, userIdx)
+    const userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
+    await model.users.deactivate(tr, userIdx)
 
     try {
-      await model.users.authenticate(c, username, password)
+      await model.users.authenticate(tr, username, password)
     } catch (e) {
       if (e instanceof NotActivatedError) {
         t.pass()
@@ -78,22 +78,22 @@ test('reject not activated user', async t => {
 })
 
 test('add and delete user membership', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
-    const groupIdx = await createGroup(c, model)
-    const userMembershipIdx = await model.users.addUserMembership(c, userIdx, groupIdx)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
+    const groupIdx = await createGroup(tr, model)
+    const userMembershipIdx = await model.users.addUserMembership(tr, userIdx, groupIdx)
 
     const query = 'SELECT * FROM user_memberships WHERE idx = $1'
-    const result = await c.query(query, [userMembershipIdx])
+    const result = await tr.query(query, [userMembershipIdx])
 
     t.truthy(result.rows[0])
     t.is(result.rows[0].user_idx, userIdx)
     t.is(result.rows[0].group_idx, groupIdx)
 
-    t.is(await model.users.deleteUserMembership(c, userMembershipIdx), userMembershipIdx)
+    t.is(await model.users.deleteUserMembership(tr, userMembershipIdx), userMembershipIdx)
 
     try {
-      await model.users.deleteUserMembership(c, userMembershipIdx)
+      await model.users.deleteUserMembership(tr, userMembershipIdx)
     } catch (e) {
       if (e instanceof NoSuchEntryError) {
         return
@@ -105,46 +105,46 @@ test('add and delete user membership', async t => {
 })
 
 test('get all user memberships', async t => {
-  await model.pgDo(async c => {
-    const userIdx = await createUser(c, model)
-    const groupIdx1 = await createGroup(c, model)
-    const groupIdx2 = await createGroup(c, model)
+  await model.pgDo(async tr => {
+    const userIdx = await createUser(tr, model)
+    const groupIdx1 = await createGroup(tr, model)
+    const groupIdx2 = await createGroup(tr, model)
 
-    const idx1 = await model.users.addUserMembership(c, userIdx, groupIdx1)
-    const idx2 = await model.users.addUserMembership(c, userIdx, groupIdx2)
+    const idx1 = await model.users.addUserMembership(tr, userIdx, groupIdx1)
+    const idx2 = await model.users.addUserMembership(tr, userIdx, groupIdx2)
 
-    const result = await model.users.getAllUserMemberships(c, userIdx)
+    const result = await model.users.getAllUserMemberships(tr, userIdx)
 
     t.deepEqual(result.map(um => um.groupIdx).sort(), [groupIdx1, groupIdx2].sort())
   })
 })
 
 test('change password', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const username = uuid()
     const password = uuid()
-    const emailIdx = await model.emailAddresses.create(c, uuid(), uuid())
-    const userIdx = await model.users.create(c, username, password, uuid(), '/bin/bash', 'en')
+    const emailIdx = await model.emailAddresses.create(tr, uuid(), uuid())
+    const userIdx = await model.users.create(tr, username, password, uuid(), '/bin/bash', 'en')
 
     const newPassword = uuid()
-    await model.users.changePassword(c, userIdx, newPassword)
+    await model.users.changePassword(tr, userIdx, newPassword)
 
-    await model.users.authenticate(c, username, newPassword)
+    await model.users.authenticate(tr, username, newPassword)
     t.pass()
   })
 })
 
 test('change password token request with identical email idx', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
-    const oldToken = await model.users.generatePasswordChangeToken(c, userIdx)
-    const newToken = await model.users.generatePasswordChangeToken(c, userIdx)
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    const oldToken = await model.users.generatePasswordChangeToken(tr, userIdx)
+    const newToken = await model.users.generatePasswordChangeToken(tr, userIdx)
 
     const query = 'SELECT token FROM password_change_tokens WHERE user_idx = $1'
-    const result = await c.query(query, [userIdx])
+    const result = await tr.query(query, [userIdx])
     const token = result.rows[0].token
     t.is(newToken, token)
     t.not(oldToken, token)
@@ -152,25 +152,25 @@ test('change password token request with identical email idx', async t => {
 })
 
 test('token expiration', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
-    const token = await model.users.generatePasswordChangeToken(c, userIdx)
-    const expiryResult = await c.query('SELECT expires FROM password_change_tokens WHERE token = $1', [token])
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    const token = await model.users.generatePasswordChangeToken(tr, userIdx)
+    const expiryResult = await tr.query('SELECT expires FROM password_change_tokens WHERE token = $1', [token])
     const originalExpires = expiryResult.rows[0].expires
 
     const query = 'UPDATE password_change_tokens SET expires = $1 WHERE token = $2'
     let newExpiry = moment(originalExpires).subtract(12, 'hours').toDate()
-    await c.query(query, [newExpiry, token])
-    await model.users.ensureTokenNotExpired(c, token)
+    await tr.query(query, [newExpiry, token])
+    await model.users.ensureTokenNotExpired(tr, token)
 
     newExpiry = moment(originalExpires).subtract(1, 'day').toDate()
-    await c.query(query, [newExpiry, token])
+    await tr.query(query, [newExpiry, token])
 
     try {
-      await model.users.ensureTokenNotExpired(c, token)
+      await model.users.ensureTokenNotExpired(tr, token)
     } catch (e) {
       t.pass()
       return
@@ -181,33 +181,33 @@ test('token expiration', async t => {
 })
 
 test('change user shell', async t => {
-  await model.pgDo(async c => {
+  await model.pgDo(async tr => {
     const emailLocal = uuid()
     const emailDomain = uuid()
-    const emailAddressIdx = await model.emailAddresses.create(c, emailLocal, emailDomain)
-    const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    const emailAddressIdx = await model.emailAddresses.create(tr, emailLocal, emailDomain)
+    const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
     const newShell = uuid()
-    await model.shells.addShell(c, newShell)
-    await model.users.changeShell(c, userIdx, newShell)
+    await model.shells.addShell(tr, newShell)
+    await model.users.changeShell(tr, userIdx, newShell)
 
-    const currentShell = await model.users.getShell(c, userIdx)
+    const currentShell = await model.users.getShell(tr, userIdx)
     t.is(currentShell, newShell)
   })
 })
 
 test('reset resend count of expired password change token', async t => {
-  await model.pgDo(async c => {
-    const emailIdx = await model.emailAddresses.create(c, uuid(), uuid())
-    const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
-    let token = await model.users.generatePasswordChangeToken(c, userIdx)
-    const expiryResult = await c.query('SELECT expires FROM password_change_tokens WHERE token = $1', [token])
+  await model.pgDo(async tr => {
+    const emailIdx = await model.emailAddresses.create(tr, uuid(), uuid())
+    const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    let token = await model.users.generatePasswordChangeToken(tr, userIdx)
+    const expiryResult = await tr.query('SELECT expires FROM password_change_tokens WHERE token = $1', [token])
     const originalExpires = expiryResult.rows[0].expires
     const query = 'UPDATE password_change_tokens SET expires = $1, resend_count = 100 WHERE token = $2'
     const newExpiry = moment(originalExpires).subtract(2, 'day').toDate()
-    await c.query(query, [newExpiry, token])
-    token = await model.users.generatePasswordChangeToken(c, userIdx)
+    await tr.query(query, [newExpiry, token])
+    token = await model.users.generatePasswordChangeToken(tr, userIdx)
 
-    const resendCount = await model.users.getResendCount(c, token)
+    const resendCount = await model.users.getResendCount(tr, token)
     t.is(resendCount, 1)
   })
 })
@@ -219,19 +219,20 @@ test('legacy mssql password (sha512)', async t => {
     salt: Buffer.from('251C01B8', 'hex'),
     hash: Buffer.from('CF413665AC3A350E2F61EF6A8845B729CE771DD70E3FA2808C0F24CE3945A19A43F160087' +
       '60ED06D7AF5181986AC39563CE1356BA451468BD27F936FF5D1BAA9', 'hex')})
-  await model.pgDo(async c => {
-    const result = await c.query('INSERT INTO users (username, password_digest, name, uid, shell, preferred_language)' +
-      'VALUES ($1, $2, \'OLDoge\', 10, \'/bin/bash\', \'en\') RETURNING idx', [username, legacyPasswordDigest])
+  await model.pgDo(async tr => {
+    const result = await tr.query('INSERT INTO users (username, password_digest, name, uid, shell, ' +
+      'preferred_language) VALUES ($1, $2, \'OLDoge\', 10, \'/bin/bash\', \'en\') RETURNING idx',
+      [username, legacyPasswordDigest])
     const userIdx = result.rows[0].idx
     // doge should be able to login using password stored in old doggy password format
-    await model.users.authenticate(c, username, password)
+    await model.users.authenticate(tr, username, password)
     // doge should be automatically migrated to brand-new password format
-    const selectResult: string = (await c.query('SELECT password_digest FROM users WHERE username=$1',
+    const selectResult: string = (await tr.query('SELECT password_digest FROM users WHERE username=$1',
       [username])).rows[0].password_digest
     t.is(selectResult.split('$')[1], 'argon2i')
     // doge should be able to login using password stored in brand-new password format. wow.
-    await model.users.authenticate(c, username, password)
-    await model.users.delete(c, userIdx)
+    await model.users.authenticate(tr, username, password)
+    await model.users.delete(tr, userIdx)
   })
 })
 
@@ -241,13 +242,13 @@ test('user ldap search result cache test', async t => {
   const name = uuid()
   const newName = uuid()
 
-  await model.pgDo(async c => {
-    const userIdx = await model.users.create(c, username, password, name, '/bin/bash', 'en')
+  await model.pgDo(async tr => {
+    const userIdx = await model.users.create(tr, username, password, name, '/bin/bash', 'en')
     // cache it
-    await model.users.getAllAsPosixAccounts(c)
+    await model.users.getAllAsPosixAccounts(tr)
     const query = 'UPDATE users SET name = $1 WHERE idx = $2'
-    await c.query(query, [newName, userIdx])
-    let allPosixUsers = await model.users.getAllAsPosixAccounts(c)
+    await tr.query(query, [newName, userIdx])
+    let allPosixUsers = await model.users.getAllAsPosixAccounts(tr)
     let posixUser = allPosixUsers.find(elem => elem.attributes.gecos === name)
     if (!posixUser) {
       t.fail()
@@ -261,9 +262,9 @@ test('user ldap search result cache test', async t => {
     }
     // okay, we now know the cache exists. then how about cache update?
     // this will make cache invalid
-    await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+    await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
 
-    allPosixUsers = await model.users.getAllAsPosixAccounts(c)
+    allPosixUsers = await model.users.getAllAsPosixAccounts(tr)
     posixUser = allPosixUsers.find(elem => elem.attributes.gecos === name)
     // this should not exist
     if (posixUser) {

--- a/core/test/model/users.test.ts
+++ b/core/test/model/users.test.ts
@@ -33,7 +33,7 @@ test('create and delete user', async t => {
     }
 
     t.fail()
-  })
+  }, ['users'])
 })
 
 test('authenticate user', async t => {
@@ -54,7 +54,7 @@ test('authenticate user', async t => {
     }
 
     t.fail()
-  })
+  }, ['users'])
 })
 
 test('reject not activated user', async t => {
@@ -74,7 +74,7 @@ test('reject not activated user', async t => {
     }
 
     t.fail()
-  })
+  }, ['users'])
 })
 
 test('add and delete user membership', async t => {
@@ -101,7 +101,7 @@ test('add and delete user membership', async t => {
     }
 
     t.fail()
-  })
+  }, ['users'])
 })
 
 test('get all user memberships', async t => {
@@ -116,7 +116,7 @@ test('get all user memberships', async t => {
     const result = await model.users.getAllUserMemberships(tr, userIdx)
 
     t.deepEqual(result.map(um => um.groupIdx).sort(), [groupIdx1, groupIdx2].sort())
-  })
+  }, ['users'])
 })
 
 test('change password', async t => {
@@ -131,7 +131,7 @@ test('change password', async t => {
 
     await model.users.authenticate(tr, username, newPassword)
     t.pass()
-  })
+  }, ['users'])
 })
 
 test('change password token request with identical email idx', async t => {
@@ -148,7 +148,7 @@ test('change password token request with identical email idx', async t => {
     const token = result.rows[0].token
     t.is(newToken, token)
     t.not(oldToken, token)
-  })
+  }, ['users'])
 })
 
 test('token expiration', async t => {
@@ -177,7 +177,7 @@ test('token expiration', async t => {
     }
 
     t.fail()
-  })
+  }, ['users'])
 })
 
 test('change user shell', async t => {
@@ -192,7 +192,7 @@ test('change user shell', async t => {
 
     const currentShell = await model.users.getShell(tr, userIdx)
     t.is(currentShell, newShell)
-  })
+  }, ['users'])
 })
 
 test('reset resend count of expired password change token', async t => {
@@ -209,7 +209,7 @@ test('reset resend count of expired password change token', async t => {
 
     const resendCount = await model.users.getResendCount(tr, token)
     t.is(resendCount, 1)
-  })
+  }, ['users'])
 })
 
 test('legacy mssql password (sha512)', async t => {
@@ -279,5 +279,5 @@ test('user ldap search result cache test', async t => {
     }
 
     t.pass()
-  })
+  }, ['users'])
 })

--- a/core/test/model/users.test.ts
+++ b/core/test/model/users.test.ts
@@ -101,7 +101,7 @@ test('add and delete user membership', async t => {
     }
 
     t.fail()
-  }, ['users'])
+  }, ['users', 'group_reachable_cache'])
 })
 
 test('get all user memberships', async t => {
@@ -116,7 +116,7 @@ test('get all user memberships', async t => {
     const result = await model.users.getAllUserMemberships(tr, userIdx)
 
     t.deepEqual(result.map(um => um.groupIdx).sort(), [groupIdx1, groupIdx2].sort())
-  }, ['users'])
+  }, ['users', 'group_reachable_cache'])
 })
 
 test('change password', async t => {

--- a/core/test/test_utils.ts
+++ b/core/test/test_utils.ts
@@ -1,17 +1,17 @@
 import Model from '../src/model/model'
-import { PoolClient } from 'pg'
+import Transaction from '../src/model/transaction'
 import * as uuid from 'uuid/v4'
 
-export async function createEmailAddress(c: PoolClient, model: Model): Promise<number> {
-  return await model.emailAddresses.create(c, uuid(), uuid())
+export async function createEmailAddress(tr: Transaction, model: Model): Promise<number> {
+  return await model.emailAddresses.create(tr, uuid(), uuid())
 }
 
-export async function createUser(c: PoolClient, model: Model): Promise<number> {
-  const userIdx = await model.users.create(c, uuid(), uuid(), uuid(), '/bin/bash', 'en')
+export async function createUser(tr: Transaction, model: Model): Promise<number> {
+  const userIdx = await model.users.create(tr, uuid(), uuid(), uuid(), '/bin/bash', 'en')
   return userIdx
 }
 
-export async function createGroup(c: PoolClient, model: Model): Promise<number> {
+export async function createGroup(tr: Transaction, model: Model): Promise<number> {
   const name = {
     ko: uuid(),
     en: uuid(),
@@ -22,14 +22,14 @@ export async function createGroup(c: PoolClient, model: Model): Promise<number> 
     en: uuid(),
   }
 
-  return await model.groups.create(c, name, description)
+  return await model.groups.create(tr, name, description)
 }
 
-export async function createGroupRelation(c: PoolClient, model: Model, supergroupIdx: number, subgroupIdx: number) {
-  return await model.groups.addGroupRelation(c, supergroupIdx, subgroupIdx)
+export async function createGroupRelation(tr: Transaction, model: Model, supergroupIdx: number, subgroupIdx: number) {
+  return await model.groups.addGroupRelation(tr, supergroupIdx, subgroupIdx)
 }
 
-export async function createPermission(c: PoolClient, model: Model): Promise<number> {
+export async function createPermission(tr: Transaction, model: Model): Promise<number> {
   const name = {
     ko: uuid(),
     en: uuid(),
@@ -39,5 +39,5 @@ export async function createPermission(c: PoolClient, model: Model): Promise<num
     ko: uuid(),
     en: uuid(),
   }
-  return await model.permissions.create(c, name, description)
+  return await model.permissions.create(tr, name, description)
 }


### PR DESCRIPTION
ACCESS EXCLUSIVE LOCK을 요구하는 transaction이 있다면, 다른 쿼리를 실행하기에 앞서 미리 락을 얻도록 합니다. 락을 필요로 하는 쿼리가 실행될 때, 락이 얻어진 상태인지 ensure하는 메커니즘도 구현했습니다.

미래에 쓸지도 모르니 advisory lock에 대해서도 유사한 메커니즘을 구현했습니다.