### PR TITLE
Update deps

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -260,9 +260,9 @@
       }
     },
     "@phc/format": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@phc/format/-/format-0.4.3.tgz",
-      "integrity": "sha512-UEgVMbufNOVXwTgykJ1v2q6Z2T10bfVjCxV/uYZKDI+14gMemoFOzt+4h1zyqy0QNFShP6QgsU+Sn+lRPYkaYw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-0.5.0.tgz",
+      "integrity": "sha512-JWtZ5P1bfXU0bAtTzCpOLYHDXuxSVdtL/oqz4+xa97h8w9E5IlVN333wugXVFv8vZ1hbXObKQf1ptXmFFcMByg==",
       "requires": {
         "safe-buffer": "^5.1.2"
       }
@@ -549,14 +549,13 @@
       }
     },
     "argon2": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.19.3.tgz",
-      "integrity": "sha1-TlnLO89dHwnKB7RScWM0Zw75oLc=",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.21.0.tgz",
+      "integrity": "sha512-L+2aafb77i7RRv/Hk9V/qHHIJ+IjhOhEEO2YgRcFapCbepdHNH6frGvvRXAWEdGDD+SdLKo0F3evgi80eL9QEQ==",
       "requires": {
-        "@phc/format": "^0.4.2",
-        "any-promise": "^1.3.0",
-        "bindings": "^1.3.0",
-        "nan": "^2.10.0"
+        "@phc/format": "^0.5.0",
+        "bindings": "^1.4.0",
+        "node-addon-api": "^1.6.0"
       }
     },
     "argparse": {
@@ -1299,9 +1298,12 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.5.1",
@@ -2079,6 +2081,11 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -3316,9 +3323,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3902,7 +3909,8 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
     },
     "ncp": {
       "version": "2.0.0",
@@ -3914,6 +3922,11 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-addon-api": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
+      "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
     },
     "nodemailer": {
       "version": "4.6.8",

--- a/core/package.json
+++ b/core/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/bacchus-snu/id/issues"
   },
   "dependencies": {
-    "argon2": "^0.19.3",
+    "argon2": "^0.21.0",
     "axios": "^0.18.0",
     "bunyan": "^1.8.12",
     "koa": "^2.5.2",


### PR DESCRIPTION
argon2 was breaking our build, since travis now uses nodejs12. Updating argon2 fixes the build, and it still is compatible with our production nodejs version.