### PR TITLE
Add TweetNaCl public key auth

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -19,6 +19,7 @@
         "moment": "^2.22.2",
         "nodemailer": "^4.6.8",
         "pg": "^8.5.1",
+        "tweetnacl": "^1.0.3",
         "uuid": "^3.3.2"
       },
       "devDependencies": {
@@ -5922,6 +5923,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -11147,6 +11153,11 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-fest": {
       "version": "0.13.1",

--- a/core/package.json
+++ b/core/package.json
@@ -29,6 +29,7 @@
     "moment": "^2.22.2",
     "nodemailer": "^4.6.8",
     "pg": "^8.5.1",
+    "tweetnacl": "^1.0.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -159,5 +159,6 @@ create table hosts (
   idx serial primary key,
   name text not null check (name <> ''),
   host inet unique not null check (text(host) <> ''),
-  host_group integer references host_groups(idx) on delete set null
+  host_group integer references host_groups(idx) on delete set null,
+  host_pubkey bytea unique check (octet_length(host_pubkey) = 32)
 );

--- a/core/src/api/pubkey.ts
+++ b/core/src/api/pubkey.ts
@@ -1,0 +1,36 @@
+import { Context } from 'koa'
+import * as tweetnacl from 'tweetnacl'
+
+export interface VerifyResult {
+  publicKey: Buffer
+}
+
+export function verifyPubkeyReq(ctx: Context): VerifyResult | null {
+  const hostPubkey = Buffer.from(ctx.headers['x-bacchus-id-pubkey'], 'base64')
+  const reqTimestamp = parseInt(ctx.headers['x-bacchus-id-timestamp'], 10)
+  const signature = Buffer.from(ctx.headers['x-bacchus-id-signature'], 'base64')
+
+  if (
+    hostPubkey.length !== tweetnacl.sign.publicKeyLength ||
+    Number.isNaN(reqTimestamp) ||
+    signature.length !== tweetnacl.sign.signatureLength
+  ) {
+    // bad signature info
+    return null
+  }
+
+  const now = Date.now()
+  if (Math.abs(now / 1000 - reqTimestamp) > 30) {
+    // time drift
+    return null
+  }
+
+  const rawBody = ctx.request.rawBody
+  const msgText = String(reqTimestamp) + rawBody
+  const message = Buffer.from(msgText, 'utf8')
+  if (!tweetnacl.sign.detached.verify(message, signature, hostPubkey)) {
+    return null
+  }
+
+  return { publicKey: hostPubkey }
+}

--- a/core/test/api/login.test.ts
+++ b/core/test/api/login.test.ts
@@ -41,7 +41,7 @@ test('test login with credential', async t => {
   })
 })
 
-test('test PAM login with credential and host', async t => {
+test.serial('test PAM login with credential and host', async t => {
   let username: string = ''
   let password: string = ''
   let userIdx: number = -1
@@ -63,8 +63,8 @@ test('test PAM login with credential and host', async t => {
     groupIdx = await model.groups.create(tr, trans, trans)
     await model.users.addUserMembership(tr, userIdx, groupIdx)
 
-    hostIdx = await model.hosts.addHost(tr, 'test1', '127.0.0.1')
-    hostGroupIdx = await model.hosts.addHostGroup(tr, 'test group 1')
+    hostIdx = await model.hosts.addHost(tr, 'test', '127.0.0.1')
+    hostGroupIdx = await model.hosts.addHostGroup(tr, 'test group')
     await model.hosts.addHostToGroup(tr, hostIdx, hostGroupIdx)
 
     permissionIdx = await model.permissions.create(tr, trans, trans)
@@ -104,12 +104,12 @@ test('test PAM login with credential and host', async t => {
 
   // Cleanup
   await model.pgDo(async tr => {
-    await tr.query('DELETE FROM hosts WHERE name = $1', ['test1'])
-    await tr.query('DELETE FROM host_groups WHERE name = $1', ['test group 1'])
+    await tr.query('DELETE FROM hosts WHERE name = $1', ['test'])
+    await tr.query('DELETE FROM host_groups WHERE name = $1', ['test group'])
   })
 })
 
-test('test PAM login with credential and pubkey', async t => {
+test.serial('test PAM login with credential and pubkey', async t => {
   let username: string = ''
   let password: string = ''
   let userIdx: number = -1
@@ -134,8 +134,8 @@ test('test PAM login with credential and pubkey', async t => {
     groupIdx = await model.groups.create(tr, trans, trans)
     await model.users.addUserMembership(tr, userIdx, groupIdx)
 
-    hostIdx = await model.hosts.addHost(tr, 'test2', '127.0.0.2', publicKey)
-    hostGroupIdx = await model.hosts.addHostGroup(tr, 'test group 2')
+    hostIdx = await model.hosts.addHost(tr, 'test', '127.0.0.1', publicKey)
+    hostGroupIdx = await model.hosts.addHostGroup(tr, 'test group')
     await model.hosts.addHostToGroup(tr, hostIdx, hostGroupIdx)
 
     permissionIdx = await model.permissions.create(tr, trans, trans)
@@ -210,8 +210,8 @@ test('test PAM login with credential and pubkey', async t => {
 
   // Cleanup
   await model.pgDo(async tr => {
-    await tr.query('DELETE FROM hosts WHERE name = $1', ['test2'])
-    await tr.query('DELETE FROM host_groups WHERE name = $1', ['test group 2'])
+    await tr.query('DELETE FROM hosts WHERE name = $1', ['test'])
+    await tr.query('DELETE FROM host_groups WHERE name = $1', ['test group'])
   })
 })
 


### PR DESCRIPTION
[TweetNaCl] sign을 사용해서 공개 키 기반 인증을 구현했습니다. 서버에서 사용한 구현체는 [`tweetnacl`][npm-tweetnacl]입니다.

[TweetNaCl]: http://tweetnacl.cr.yp.to/
[npm-tweetnacl]: https://www.npmjs.com/package/tweetnacl

DB의 공개 키 필드는 nullable이지만 unique입니다. 또 공개 키가 등록된 호스트는 IP 기반 인증을 진행할 수 없고 공개 키 인증만 가능합니다.

## 공개 키 인증 스펙
서버는 요청 헤더에 `X-Bacchus-Id-Pubkey`가 있으면 공개 키 인증을 수행합니다.
- `-Pubkey`: 호스트 공개 키의 Base64 표현
- `-Timestamp`: 요청을 보낼 때의 UNIX 타임스탬프
- `-Signature`: `concat(X-Bacchus-Id-Timestamp, body)`을 주어진 `-Pubkey`에 해당하는 비밀 키로 서명한 데이터의 Base64 표현

서버가 공개 키 인증을 수행하는 로직은 다음과 같습니다.
1. 주어진 헤더가 올바른 값을 갖는지 확인합니다. 기본적으로 세 헤더 모두 값이 존재해야 하고, 디코딩 결과 `-Pubkey`는 32바이트, `-Signature`는 64바이트여야 하며, `-Timestamp`는 정수여야 합니다.
2. 타임스탬프와 서버 시각을 보고 차이가 너무 크지 않은지 확인합니다. 30초 넘게 차이가 나면 reject합니다.
3. 서명을 확인합니다. 서명이 올바르지 않으면 reject합니다.
4. 마지막으로 DB를 보고 해당하는 호스트가 존재하는지 확인합니다.

---

Discord 웹훅 인증을 많이 참고했습니다 헿